### PR TITLE
daw_hide.h #if uses && instead of and

### DIFF
--- a/include/daw/daw_hide.h
+++ b/include/daw/daw_hide.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#if !defined( DAW_NO_FLATTEN ) and !defined( _MSC_VER )
+#if !defined( DAW_NO_FLATTEN ) && !defined( _MSC_VER )
 #define DAW_ATTRIBUTE_FLATTEN [[gnu::flatten, gnu::always_inline]]
 #define DAW_ATTRIBUTE_HIDDEN __attribute__( ( visibility( "hidden" ) ) )
 #else


### PR DESCRIPTION
Not sure if 'and' is available in some preprocessors but it doesn't seem to work on my standard MSVC (19.29.30037) build.