### PR TITLE
fwd pack failed for empty packs because of default ctor

### DIFF
--- a/include/daw/daw_fwd_pack_apply.h
+++ b/include/daw/daw_fwd_pack_apply.h
@@ -56,6 +56,11 @@ namespace daw {
 		}
 	};
 
+	template<>
+	struct fwd_pack<> {
+		DAW_ATTRIB_FLATINLINE inline constexpr fwd_pack( ) noexcept = default;
+	};
+
 	template<typename... Ts>
 	fwd_pack( Ts &&... ) -> fwd_pack<Ts &&...>;
 

--- a/include/daw/daw_fwd_pack_apply.h
+++ b/include/daw/daw_fwd_pack_apply.h
@@ -58,7 +58,6 @@ namespace daw {
 
 	template<>
 	struct fwd_pack<> {
-		DAW_ATTRIB_FLATINLINE inline constexpr fwd_pack( ) noexcept = default;
 	};
 
 	template<typename... Ts>


### PR DESCRIPTION
Specialized empty fwd_pack