### PR TITLE
Added forward_nontemp_as_tuple that behaves like forward_as_tuple but

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project("header_libraries"
-        VERSION "1.17.8"
+        VERSION "1.18.0"
         DESCRIPTION "Various headers"
         HOMEPAGE_URL "https://github.com/beached/header_libraries"
         LANGUAGES C CXX)

--- a/include/daw/daw_tuple_helper.h
+++ b/include/daw/daw_tuple_helper.h
@@ -508,4 +508,12 @@ namespace daw {
 
 	template<typename Tuple>
 	inline constexpr bool is_empty_tuple_v = ( tuple_size_v<Tuple> == 0 );
+
+	template<typename... Ts>
+	constexpr auto forward_nontemp_as_tuple( Ts &&...values ) {
+		using tuple_t =
+		  std::tuple<std::conditional_t<std::is_rvalue_reference_v<Ts>,
+		                                daw::remove_cvref_t<Ts>, Ts>...>;
+		return tuple_t{ DAW_FWD( values )... };
+	}
 } // namespace daw


### PR DESCRIPTION
stores rvalue refs as values, not references