### PR TITLE
Added defensive brackets around min/max func calls/definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project("daw-header-libraries"
-        VERSION "1.24.0"
+        VERSION "1.25.0"
         DESCRIPTION "Various headers"
         HOMEPAGE_URL "https://github.com/beached/header_libraries"
         LANGUAGES C CXX)

--- a/include/daw/cpp_17.h
+++ b/include/daw/cpp_17.h
@@ -395,7 +395,7 @@ namespace daw {
 #endif
 			template<typename T, typename U>
 			[[nodiscard, maybe_unused]] constexpr std::common_type_t<T, U>
-			min( T const &lhs, U const &rhs ) noexcept {
+			(min)( T const &lhs, U const &rhs ) noexcept {
 				if( lhs <= rhs ) {
 					return lhs;
 				}

--- a/include/daw/cpp_17.h
+++ b/include/daw/cpp_17.h
@@ -394,8 +394,8 @@ namespace daw {
 #undef min
 #endif
 			template<typename T, typename U>
-			[[nodiscard, maybe_unused]] constexpr std::common_type_t<T, U>
-			(min)( T const &lhs, U const &rhs ) noexcept {
+			[[nodiscard, maybe_unused]] constexpr std::common_type_t<T, U>( min )(
+			  T const &lhs, U const &rhs ) noexcept {
 				if( lhs <= rhs ) {
 					return lhs;
 				}
@@ -691,4 +691,3 @@ namespace daw {
 	template<typename Function, typename... Params>
 	bind_front( Function, Params... ) -> bind_front<Function, Params...>;
 } // namespace daw
-

--- a/include/daw/daw_algorithm.h
+++ b/include/daw/daw_algorithm.h
@@ -96,7 +96,7 @@ namespace daw {
 					return;
 				}
 				dist = -dist;
-				it -= daw::min( static_cast<ptrdiff_t>( dist_to_first ),
+				it -= (daw::min)( static_cast<ptrdiff_t>( dist_to_first ),
 				                static_cast<ptrdiff_t>( dist ) );
 				return;
 			}
@@ -105,7 +105,7 @@ namespace daw {
 				it = last;
 				return;
 			}
-			it += daw::min( static_cast<ptrdiff_t>( dist_to_last ),
+			it += (daw::min)( static_cast<ptrdiff_t>( dist_to_last ),
 			                static_cast<ptrdiff_t>( dist ) );
 		}
 	} // namespace algorithm_details

--- a/include/daw/daw_algorithm.h
+++ b/include/daw/daw_algorithm.h
@@ -96,8 +96,8 @@ namespace daw {
 					return;
 				}
 				dist = -dist;
-				it -= (daw::min)( static_cast<ptrdiff_t>( dist_to_first ),
-				                static_cast<ptrdiff_t>( dist ) );
+				it -= ( daw::min )( static_cast<ptrdiff_t>( dist_to_first ),
+				                    static_cast<ptrdiff_t>( dist ) );
 				return;
 			}
 			auto const dist_to_last = last - it;
@@ -105,8 +105,8 @@ namespace daw {
 				it = last;
 				return;
 			}
-			it += (daw::min)( static_cast<ptrdiff_t>( dist_to_last ),
-			                static_cast<ptrdiff_t>( dist ) );
+			it += ( daw::min )( static_cast<ptrdiff_t>( dist_to_last ),
+			                    static_cast<ptrdiff_t>( dist ) );
 		}
 	} // namespace algorithm_details
 

--- a/include/daw/daw_arith_traits.h
+++ b/include/daw/daw_arith_traits.h
@@ -77,7 +77,7 @@ namespace daw {
 		// static constexpr bool traps = true;
 		static constexpr bool tinyness_before = false;
 
-		static constexpr __int128 min( ) noexcept {
+		static constexpr __int128 (min)( ) noexcept {
 			return static_cast<__int128>(
 			  static_cast<__uint128_t>( 0x8000'0000'0000'0000ULL ) << 64U );
 		}
@@ -87,7 +87,7 @@ namespace daw {
 			  static_cast<__uint128_t>( 0x8000'0000'0000'0000ULL ) << 64U );
 		}
 
-		static constexpr __int128 max( ) noexcept {
+		static constexpr __int128 (max)( ) noexcept {
 			return static_cast<__int128>(
 			  ( static_cast<__uint128_t>( 0x7FFF'FFFF'FFFF'FFFFULL ) << 64U ) |
 			  ( static_cast<__uint128_t>( 0xFFFF'FFFF'FFFF'FFFFULL ) ) );
@@ -147,7 +147,7 @@ namespace daw {
 		// static constexpr bool traps = true;
 		static constexpr bool tinyness_before = false;
 
-		static constexpr __uint128_t min( ) noexcept {
+		static constexpr __uint128_t (min)( ) noexcept {
 			return 0;
 		}
 
@@ -155,7 +155,7 @@ namespace daw {
 			return 0;
 		}
 
-		static constexpr __uint128_t max( ) noexcept {
+		static constexpr __uint128_t (max)( ) noexcept {
 			return static_cast<__uint128_t>(
 			  ( static_cast<__uint128_t>( 0xFFFF'FFFF'FFFF'FFFFULL ) << 64U ) |
 			  ( static_cast<__uint128_t>( 0xFFFF'FFFF'FFFF'FFFFULL ) ) );

--- a/include/daw/daw_arith_traits.h
+++ b/include/daw/daw_arith_traits.h
@@ -77,7 +77,7 @@ namespace daw {
 		// static constexpr bool traps = true;
 		static constexpr bool tinyness_before = false;
 
-		static constexpr __int128 (min)( ) noexcept {
+		static constexpr __int128( min )( ) noexcept {
 			return static_cast<__int128>(
 			  static_cast<__uint128_t>( 0x8000'0000'0000'0000ULL ) << 64U );
 		}
@@ -87,7 +87,7 @@ namespace daw {
 			  static_cast<__uint128_t>( 0x8000'0000'0000'0000ULL ) << 64U );
 		}
 
-		static constexpr __int128 (max)( ) noexcept {
+		static constexpr __int128( max )( ) noexcept {
 			return static_cast<__int128>(
 			  ( static_cast<__uint128_t>( 0x7FFF'FFFF'FFFF'FFFFULL ) << 64U ) |
 			  ( static_cast<__uint128_t>( 0xFFFF'FFFF'FFFF'FFFFULL ) ) );
@@ -147,7 +147,7 @@ namespace daw {
 		// static constexpr bool traps = true;
 		static constexpr bool tinyness_before = false;
 
-		static constexpr __uint128_t (min)( ) noexcept {
+		static constexpr __uint128_t( min )( ) noexcept {
 			return 0;
 		}
 
@@ -155,7 +155,7 @@ namespace daw {
 			return 0;
 		}
 
-		static constexpr __uint128_t (max)( ) noexcept {
+		static constexpr __uint128_t( max )( ) noexcept {
 			return static_cast<__uint128_t>(
 			  ( static_cast<__uint128_t>( 0xFFFF'FFFF'FFFF'FFFFULL ) << 64U ) |
 			  ( static_cast<__uint128_t>( 0xFFFF'FFFF'FFFF'FFFFULL ) ) );
@@ -270,7 +270,7 @@ namespace daw {
 	inline constexpr bool is_arithmetic_v = is_arithmetic<T>::value;
 
 	template<typename T>
-	struct make_unsigned: std::make_unsigned<T> {};
+	struct make_unsigned : std::make_unsigned<T> {};
 
 #if defined( DAW_HAS_INT128 )
 	template<>
@@ -315,19 +315,17 @@ namespace daw {
 #endif
 
 	template<typename T>
-	using make_unsigned_t = typename make_unsigned<T>::type;	
-
+	using make_unsigned_t = typename make_unsigned<T>::type;
 
 	template<typename T>
-	struct is_system_integral: std::is_integral<T> { };
+	struct is_system_integral : std::is_integral<T> {};
 
 #if defined( DAW_HAS_INT128 )
 	template<>
-	struct is_system_integral<__uint128_t>: std::true_type {};
+	struct is_system_integral<__uint128_t> : std::true_type {};
 	template<>
-	struct is_system_integral<__int128_t>: std::true_type {};
+	struct is_system_integral<__int128_t> : std::true_type {};
 #endif
 	template<typename T>
 	inline constexpr bool is_system_integral_v = is_system_integral<T>::value;
 } // namespace daw
-

--- a/include/daw/daw_assume.h
+++ b/include/daw/daw_assume.h
@@ -16,11 +16,11 @@
 
 #define DAW_ASSUME( ... ) assert( ( __VA_ARGS__ ) )
 
-#elif DAW_HAS_BUILTIN(__builtin_assume)
+#elif DAW_HAS_BUILTIN( __builtin_assume )
 
-#define DAW_ASSUME( ... ) __builtin_assume( (__VA_ARGS__) )
+#define DAW_ASSUME( ... ) __builtin_assume( ( __VA_ARGS__ ) )
 
-#elif DAW_HAS_BUILTIN(__builtin_unreachable)
+#elif DAW_HAS_BUILTIN( __builtin_unreachable )
 
 #define DAW_ASSUME( ... )                                                      \
 	do {                                                                         \

--- a/include/daw/daw_benchmark.h
+++ b/include/daw/daw_benchmark.h
@@ -189,7 +189,7 @@ namespace daw {
 
 		result_t result{ };
 
-		double base_time = (std::numeric_limits<double>::max)( );
+		double base_time = ( std::numeric_limits<double>::max )( );
 		{
 			for( size_t n = 0; n < 1000; ++n ) {
 				daw::do_not_optimize( args... );
@@ -210,7 +210,7 @@ namespace daw {
 				}
 			}
 		}
-		double min_time = (std::numeric_limits<double>::max)( );
+		double min_time = ( std::numeric_limits<double>::max )( );
 		double max_time = 0.0;
 
 		auto const total_start = std::chrono::steady_clock::now( );
@@ -282,7 +282,7 @@ namespace daw {
 		static_assert( Runs > 0 );
 		auto results = std::array<double, Runs>{ };
 
-		double base_time = (std::numeric_limits<double>::max)( );
+		double base_time = ( std::numeric_limits<double>::max )( );
 		{
 			for( size_t n = 0; n < 1000; ++n ) {
 				daw::do_not_optimize( args... );
@@ -337,7 +337,7 @@ namespace daw {
 
 		result_t result{ };
 
-		double base_time = (std::numeric_limits<double>::max)( );
+		double base_time = ( std::numeric_limits<double>::max )( );
 		{
 			for( size_t n = 0; n < 1000; ++n ) {
 				daw::do_not_optimize( args... );
@@ -358,7 +358,7 @@ namespace daw {
 				}
 			}
 		}
-		double min_time = (std::numeric_limits<double>::max)( );
+		double min_time = ( std::numeric_limits<double>::max )( );
 		double max_time = 0.0;
 
 		auto const total_start = std::chrono::steady_clock::now( );
@@ -434,7 +434,7 @@ namespace daw {
 		std::vector<std::chrono::nanoseconds> results( Runs );
 
 		auto base_time =
-		  std::chrono::nanoseconds( (std::numeric_limits<long long>::max)( ) );
+		  std::chrono::nanoseconds( ( std::numeric_limits<long long>::max )( ) );
 		{
 			for( size_t n = 0; n < 1000; ++n ) {
 				daw::do_not_optimize( args... );
@@ -488,7 +488,7 @@ namespace daw {
 		std::vector<std::chrono::nanoseconds> results( Runs );
 
 		auto base_time =
-		  std::chrono::nanoseconds( (std::numeric_limits<long long>::max)( ) );
+		  std::chrono::nanoseconds( ( std::numeric_limits<long long>::max )( ) );
 		{
 			for( size_t n = 0; n < 1000; ++n ) {
 				daw::do_not_optimize( args... );

--- a/include/daw/daw_benchmark.h
+++ b/include/daw/daw_benchmark.h
@@ -189,7 +189,7 @@ namespace daw {
 
 		result_t result{ };
 
-		double base_time = std::numeric_limits<double>::max( );
+		double base_time = (std::numeric_limits<double>::max)( );
 		{
 			for( size_t n = 0; n < 1000; ++n ) {
 				daw::do_not_optimize( args... );
@@ -210,7 +210,7 @@ namespace daw {
 				}
 			}
 		}
-		double min_time = std::numeric_limits<double>::max( );
+		double min_time = (std::numeric_limits<double>::max)( );
 		double max_time = 0.0;
 
 		auto const total_start = std::chrono::steady_clock::now( );
@@ -282,7 +282,7 @@ namespace daw {
 		static_assert( Runs > 0 );
 		auto results = std::array<double, Runs>{ };
 
-		double base_time = std::numeric_limits<double>::max( );
+		double base_time = (std::numeric_limits<double>::max)( );
 		{
 			for( size_t n = 0; n < 1000; ++n ) {
 				daw::do_not_optimize( args... );
@@ -337,7 +337,7 @@ namespace daw {
 
 		result_t result{ };
 
-		double base_time = std::numeric_limits<double>::max( );
+		double base_time = (std::numeric_limits<double>::max)( );
 		{
 			for( size_t n = 0; n < 1000; ++n ) {
 				daw::do_not_optimize( args... );
@@ -358,7 +358,7 @@ namespace daw {
 				}
 			}
 		}
-		double min_time = std::numeric_limits<double>::max( );
+		double min_time = (std::numeric_limits<double>::max)( );
 		double max_time = 0.0;
 
 		auto const total_start = std::chrono::steady_clock::now( );
@@ -434,7 +434,7 @@ namespace daw {
 		std::vector<std::chrono::nanoseconds> results( Runs );
 
 		auto base_time =
-		  std::chrono::nanoseconds( std::numeric_limits<long long>::max( ) );
+		  std::chrono::nanoseconds( (std::numeric_limits<long long>::max)( ) );
 		{
 			for( size_t n = 0; n < 1000; ++n ) {
 				daw::do_not_optimize( args... );
@@ -488,7 +488,7 @@ namespace daw {
 		std::vector<std::chrono::nanoseconds> results( Runs );
 
 		auto base_time =
-		  std::chrono::nanoseconds( std::numeric_limits<long long>::max( ) );
+		  std::chrono::nanoseconds( (std::numeric_limits<long long>::max)( ) );
 		{
 			for( size_t n = 0; n < 1000; ++n ) {
 				daw::do_not_optimize( args... );

--- a/include/daw/daw_bit.h
+++ b/include/daw/daw_bit.h
@@ -18,7 +18,7 @@ namespace daw {
 	template<typename T>
 	[[deprecated( "Use mask_msb" )]] constexpr T
 	get_left_mask( size_t left_zero_bits ) noexcept {
-		return static_cast<T>( std::numeric_limits<T>::max( ) >> left_zero_bits );
+		return static_cast<T>( (std::numeric_limits<T>::max)( ) >> left_zero_bits );
 	}
 
 	template<typename T>
@@ -26,13 +26,13 @@ namespace daw {
 		if( bit_count >= daw::bsizeof<T> ) {
 			return static_cast<T>( 0 );
 		}
-		return static_cast<T>( std::numeric_limits<T>::max( ) >> bit_count );
+		return static_cast<T>( (std::numeric_limits<T>::max)( ) >> bit_count );
 	}
 
 	template<typename T>
 	[[deprecated( "Use mask_lsb" )]] constexpr T
 	get_right_mask( size_t right_zero_bits ) noexcept {
-		return static_cast<T>( std::numeric_limits<T>::max( ) << right_zero_bits );
+		return static_cast<T>( (std::numeric_limits<T>::max)( ) << right_zero_bits );
 	}
 
 	template<typename T>
@@ -40,7 +40,7 @@ namespace daw {
 		if( bit_count >= daw::bsizeof<T> ) {
 			return static_cast<T>( 0 );
 		}
-		return static_cast<T>( std::numeric_limits<T>::max( ) << bit_count );
+		return static_cast<T>( (std::numeric_limits<T>::max)( ) << bit_count );
 	}
 
 	template<typename Bit, typename... Bits>

--- a/include/daw/daw_bit.h
+++ b/include/daw/daw_bit.h
@@ -18,7 +18,8 @@ namespace daw {
 	template<typename T>
 	[[deprecated( "Use mask_msb" )]] constexpr T
 	get_left_mask( size_t left_zero_bits ) noexcept {
-		return static_cast<T>( (std::numeric_limits<T>::max)( ) >> left_zero_bits );
+		return static_cast<T>( ( std::numeric_limits<T>::max )( ) >>
+		                       left_zero_bits );
 	}
 
 	template<typename T>
@@ -26,13 +27,14 @@ namespace daw {
 		if( bit_count >= daw::bsizeof<T> ) {
 			return static_cast<T>( 0 );
 		}
-		return static_cast<T>( (std::numeric_limits<T>::max)( ) >> bit_count );
+		return static_cast<T>( ( std::numeric_limits<T>::max )( ) >> bit_count );
 	}
 
 	template<typename T>
 	[[deprecated( "Use mask_lsb" )]] constexpr T
 	get_right_mask( size_t right_zero_bits ) noexcept {
-		return static_cast<T>( (std::numeric_limits<T>::max)( ) << right_zero_bits );
+		return static_cast<T>( ( std::numeric_limits<T>::max )( )
+		                       << right_zero_bits );
 	}
 
 	template<typename T>
@@ -40,7 +42,7 @@ namespace daw {
 		if( bit_count >= daw::bsizeof<T> ) {
 			return static_cast<T>( 0 );
 		}
-		return static_cast<T>( (std::numeric_limits<T>::max)( ) << bit_count );
+		return static_cast<T>( ( std::numeric_limits<T>::max )( ) << bit_count );
 	}
 
 	template<typename Bit, typename... Bits>

--- a/include/daw/daw_bounded_graph.h
+++ b/include/daw/daw_bounded_graph.h
@@ -33,7 +33,7 @@ namespace daw {
 
 	class node_id_t {
 		static inline constexpr size_t const NO_ID =
-		  (std::numeric_limits<size_t>::max)( );
+		  ( std::numeric_limits<size_t>::max )( );
 
 		size_t m_value = NO_ID;
 

--- a/include/daw/daw_bounded_graph.h
+++ b/include/daw/daw_bounded_graph.h
@@ -33,7 +33,7 @@ namespace daw {
 
 	class node_id_t {
 		static inline constexpr size_t const NO_ID =
-		  std::numeric_limits<size_t>::max( );
+		  (std::numeric_limits<size_t>::max)( );
 
 		size_t m_value = NO_ID;
 

--- a/include/daw/daw_bounded_string.h
+++ b/include/daw/daw_bounded_string.h
@@ -58,7 +58,7 @@ namespace daw {
 
 	public:
 		static constexpr size_type const npos =
-		  (std::numeric_limits<size_type>::max)( );
+		  ( std::numeric_limits<size_type>::max )( );
 
 		// Constructors
 
@@ -74,7 +74,7 @@ namespace daw {
 		template<size_t N>
 		constexpr basic_bounded_string( basic_bounded_string<CharT, N> str,
 		                                size_type count )
-		  : m_data( str.data( ), (daw::min)( count, N ) ) {}
+		  : m_data( str.data( ), ( daw::min )( count, N ) ) {}
 
 #ifndef NOSTRING
 		template<typename Tr, typename Al>
@@ -340,7 +340,7 @@ namespace daw {
 			daw::exception::precondition_check<std::out_of_range>(
 			  pos < size( ), "Attempt to access basic_bounded_string past end" );
 
-			size_type rlen = (daw::min)( count, size( ) - pos );
+			size_type rlen = ( daw::min )( count, size( ) - pos );
 			daw::algorithm::copy_n( m_data.data( ) + pos, dest, rlen );
 			return rlen;
 		}
@@ -351,7 +351,7 @@ namespace daw {
 			  pos < size( ), "Attempt to access basic_bounded_string past end" );
 
 			auto const rcount =
-			  static_cast<size_type>( (daw::min)( count, size( ) - pos ) );
+			  static_cast<size_type>( ( daw::min )( count, size( ) - pos ) );
 			return basic_bounded_string{ &m_data[pos], rcount };
 		}
 
@@ -376,7 +376,7 @@ namespace daw {
 			};
 
 			auto cmp = str_compare( lhs.data( ), rhs.data( ),
-			                        (daw::min)( lhs.size( ), rhs.size( ) ) );
+			                        ( daw::min )( lhs.size( ), rhs.size( ) ) );
 			if( cmp == 0 ) {
 				if( lhs.size( ) < rhs.size( ) ) {
 					return -1;
@@ -408,8 +408,8 @@ namespace daw {
 				return 0;
 			};
 
-			auto cmp =
-			  str_compare( lhs.data( ), rhs_ptr, (daw::min)( lhs.size( ), rhs_size ) );
+			auto cmp = str_compare( lhs.data( ), rhs_ptr,
+			                        ( daw::min )( lhs.size( ), rhs_size ) );
 			if( cmp == 0 ) {
 				if( lhs.size( ) < rhs_size ) {
 					return -1;

--- a/include/daw/daw_bounded_string.h
+++ b/include/daw/daw_bounded_string.h
@@ -58,7 +58,7 @@ namespace daw {
 
 	public:
 		static constexpr size_type const npos =
-		  std::numeric_limits<size_type>::max( );
+		  (std::numeric_limits<size_type>::max)( );
 
 		// Constructors
 
@@ -74,7 +74,7 @@ namespace daw {
 		template<size_t N>
 		constexpr basic_bounded_string( basic_bounded_string<CharT, N> str,
 		                                size_type count )
-		  : m_data( str.data( ), daw::min( count, N ) ) {}
+		  : m_data( str.data( ), (daw::min)( count, N ) ) {}
 
 #ifndef NOSTRING
 		template<typename Tr, typename Al>
@@ -340,7 +340,7 @@ namespace daw {
 			daw::exception::precondition_check<std::out_of_range>(
 			  pos < size( ), "Attempt to access basic_bounded_string past end" );
 
-			size_type rlen = daw::min( count, size( ) - pos );
+			size_type rlen = (daw::min)( count, size( ) - pos );
 			daw::algorithm::copy_n( m_data.data( ) + pos, dest, rlen );
 			return rlen;
 		}
@@ -351,7 +351,7 @@ namespace daw {
 			  pos < size( ), "Attempt to access basic_bounded_string past end" );
 
 			auto const rcount =
-			  static_cast<size_type>( daw::min( count, size( ) - pos ) );
+			  static_cast<size_type>( (daw::min)( count, size( ) - pos ) );
 			return basic_bounded_string{ &m_data[pos], rcount };
 		}
 
@@ -376,7 +376,7 @@ namespace daw {
 			};
 
 			auto cmp = str_compare( lhs.data( ), rhs.data( ),
-			                        daw::min( lhs.size( ), rhs.size( ) ) );
+			                        (daw::min)( lhs.size( ), rhs.size( ) ) );
 			if( cmp == 0 ) {
 				if( lhs.size( ) < rhs.size( ) ) {
 					return -1;
@@ -409,7 +409,7 @@ namespace daw {
 			};
 
 			auto cmp =
-			  str_compare( lhs.data( ), rhs_ptr, daw::min( lhs.size( ), rhs_size ) );
+			  str_compare( lhs.data( ), rhs_ptr, (daw::min)( lhs.size( ), rhs_size ) );
 			if( cmp == 0 ) {
 				if( lhs.size( ) < rhs_size ) {
 					return -1;

--- a/include/daw/daw_bounded_vector.h
+++ b/include/daw/daw_bounded_vector.h
@@ -47,9 +47,9 @@ namespace daw {
 		constexpr bounded_vector_t( ) noexcept = default;
 
 		constexpr bounded_vector_t( const_pointer ptr, size_type count ) noexcept
-		  : m_index{ daw::min( count, N ) } {
+		  : m_index{ (daw::min)( count, N ) } {
 
-			daw::algorithm::copy_n( ptr, m_stack.begin( ), daw::min( count, N ) );
+			daw::algorithm::copy_n( ptr, m_stack.begin( ), (daw::min)( count, N ) );
 		}
 
 		template<typename Iterator>

--- a/include/daw/daw_bounded_vector.h
+++ b/include/daw/daw_bounded_vector.h
@@ -47,9 +47,9 @@ namespace daw {
 		constexpr bounded_vector_t( ) noexcept = default;
 
 		constexpr bounded_vector_t( const_pointer ptr, size_type count ) noexcept
-		  : m_index{ (daw::min)( count, N ) } {
+		  : m_index{ ( daw::min )( count, N ) } {
 
-			daw::algorithm::copy_n( ptr, m_stack.begin( ), (daw::min)( count, N ) );
+			daw::algorithm::copy_n( ptr, m_stack.begin( ), ( daw::min )( count, N ) );
 		}
 
 		template<typename Iterator>

--- a/include/daw/daw_clumpy_sparsy.h
+++ b/include/daw/daw_clumpy_sparsy.h
@@ -140,7 +140,7 @@ namespace daw {
 		using const_reference = typename clumpy_sparsy<T>::const_reference;
 
 	private:
-		size_t m_position = (std::numeric_limits<size_t>::max)( );
+		size_t m_position = ( std::numeric_limits<size_t>::max )( );
 		clumpy_sparsy<T> *m_items = nullptr;
 
 	public:
@@ -148,7 +148,7 @@ namespace daw {
 
 		constexpr clumpy_sparsy_iterator( clumpy_sparsy<T> *items,
 		                                  size_t position = 0 ) noexcept
-		  : m_position( items ? position : (std::numeric_limits<size_t>::max)( ) )
+		  : m_position( items ? position : ( std::numeric_limits<size_t>::max )( ) )
 		  , m_items( items ? items : nullptr ) {}
 
 	private:

--- a/include/daw/daw_clumpy_sparsy.h
+++ b/include/daw/daw_clumpy_sparsy.h
@@ -140,7 +140,7 @@ namespace daw {
 		using const_reference = typename clumpy_sparsy<T>::const_reference;
 
 	private:
-		size_t m_position = std::numeric_limits<size_t>::max( );
+		size_t m_position = (std::numeric_limits<size_t>::max)( );
 		clumpy_sparsy<T> *m_items = nullptr;
 
 	public:
@@ -148,7 +148,7 @@ namespace daw {
 
 		constexpr clumpy_sparsy_iterator( clumpy_sparsy<T> *items,
 		                                  size_t position = 0 ) noexcept
-		  : m_position( items ? position : std::numeric_limits<size_t>::max( ) )
+		  : m_position( items ? position : (std::numeric_limits<size_t>::max)( ) )
 		  , m_items( items ? items : nullptr ) {}
 
 	private:

--- a/include/daw/daw_construct_at.h
+++ b/include/daw/daw_construct_at.h
@@ -33,8 +33,7 @@ namespace daw {
 
 	template<typename T, typename Storage, typename... Args>
 	inline constexpr T *construct_at( Storage *p, Args &&...args ) {
-		return std::construct_at( reinterpret_cast<T*>( p ), DAW_FWD( args )... );
+		return std::construct_at( reinterpret_cast<T *>( p ), DAW_FWD( args )... );
 	}
 #endif
-}
-
+} // namespace daw

--- a/include/daw/daw_container_algorithm.h
+++ b/include/daw/daw_container_algorithm.h
@@ -457,7 +457,7 @@ namespace daw {
 		constexpr void copy_n( Container const &source, size_t count,
 		                       OutputIterator destination ) {
 			auto src = std::cbegin( source );
-			count = daw::min( count, daw::size( source ) );
+			count = (daw::min)( count, daw::size( source ) );
 			for( size_t n = 0; n < count; ++n ) {
 				*destination++ = *src++;
 			}
@@ -504,7 +504,7 @@ namespace daw {
 			  "information" );
 
 			auto src = std::cbegin( source );
-			count = daw::min( count, daw::size( source ) );
+			count = (daw::min)( count, daw::size( source ) );
 			for( size_t n = 0; n < count; ++n ) {
 				if( pred( *src ) ) {
 					*destination++ = *src++;

--- a/include/daw/daw_container_algorithm.h
+++ b/include/daw/daw_container_algorithm.h
@@ -457,7 +457,7 @@ namespace daw {
 		constexpr void copy_n( Container const &source, size_t count,
 		                       OutputIterator destination ) {
 			auto src = std::cbegin( source );
-			count = (daw::min)( count, daw::size( source ) );
+			count = ( daw::min )( count, daw::size( source ) );
 			for( size_t n = 0; n < count; ++n ) {
 				*destination++ = *src++;
 			}
@@ -504,7 +504,7 @@ namespace daw {
 			  "information" );
 
 			auto src = std::cbegin( source );
-			count = (daw::min)( count, daw::size( source ) );
+			count = ( daw::min )( count, daw::size( source ) );
 			for( size_t n = 0; n < count; ++n ) {
 				if( pred( *src ) ) {
 					*destination++ = *src++;

--- a/include/daw/daw_container_traits.h
+++ b/include/daw/daw_container_traits.h
@@ -19,7 +19,7 @@
 
 namespace daw {
 	inline constexpr std::size_t DynamicExtent =
-	  (std::numeric_limits<std::size_t>::max)( );
+	  ( std::numeric_limits<std::size_t>::max )( );
 
 	template<typename Container>
 	struct container_traits {

--- a/include/daw/daw_container_traits.h
+++ b/include/daw/daw_container_traits.h
@@ -19,7 +19,7 @@
 
 namespace daw {
 	inline constexpr std::size_t DynamicExtent =
-	  std::numeric_limits<std::size_t>::max( );
+	  (std::numeric_limits<std::size_t>::max)( );
 
 	template<typename Container>
 	struct container_traits {

--- a/include/daw/daw_cpp_feature_check.h
+++ b/include/daw/daw_cpp_feature_check.h
@@ -19,14 +19,15 @@
 #define DAW_HAS_INCLUDE( ... ) ( false )
 #endif
 
-#if defined(__has_builtin)
-#define DAW_HAS_BUILTIN( ... ) __has_builtin(__VA_ARGS__)
+#if defined( __has_builtin )
+#define DAW_HAS_BUILTIN( ... ) __has_builtin( __VA_ARGS__ )
 #else
 #define DAW_HAS_BUILTIN( ... ) ( false )
 #endif
 
 // Do not use when -Wundef is at play as -Werror will make it not build
-#define DAW_HAS_FEATURE( feature ) ( (feature) > 0 )
+#define DAW_HAS_FEATURE( feature ) ( ( feature ) > 0 )
 
 // Do not use when -Wundef is at play as -Werror will make it not build
-#define DAW_HAS_FEATURE_VERSION( feature, version ) ( (feature) > (version) )
+#define DAW_HAS_FEATURE_VERSION( feature, version )                            \
+	( ( feature ) > ( version ) )

--- a/include/daw/daw_cxmath.h
+++ b/include/daw/daw_cxmath.h
@@ -283,13 +283,13 @@ namespace daw::cxmath {
 		[[nodiscard]] constexpr Float pow2_impl2( intmax_t exp ) noexcept {
 			bool is_neg = exp < 0;
 			exp = is_neg ? -exp : exp;
-			auto const max_shft = (daw::min)(
+			auto const max_shft = ( daw::min )(
 			  static_cast<size_t>( daw::numeric_limits<Float>::max_exponent10 ),
 			  ( sizeof( size_t ) * 8ULL ) );
 			Float result = 1.0;
 
 			while( static_cast<size_t>( exp ) >= max_shft ) {
-				result *= static_cast<Float>( (daw::numeric_limits<size_t>::max)( ) );
+				result *= static_cast<Float>( ( daw::numeric_limits<size_t>::max )( ) );
 				exp -= max_shft;
 			}
 			if( exp > 0 ) {
@@ -321,8 +321,8 @@ namespace daw::cxmath {
 			exp = is_neg ? -exp : exp;
 
 			auto const max_spow =
-			  (daw::min)( daw::numeric_limits<Float>::max_exponent10,
-			            daw::numeric_limits<size_t>::digits10 );
+			  ( daw::min )( daw::numeric_limits<Float>::max_exponent10,
+			                daw::numeric_limits<size_t>::digits10 );
 			Float result = 1.0;
 
 			while( exp >= max_spow ) {
@@ -539,11 +539,11 @@ namespace daw::cxmath {
 		if( f == 0.0f ) {
 			return static_cast<std::int32_t>( 0 );
 		}
-		if( f > (daw::numeric_limits<Real>::max)( ) ) {
+		if( f > ( daw::numeric_limits<Real>::max )( ) ) {
 			// inf
 			return std::nullopt;
 		}
-		if( f < -(daw::numeric_limits<Real>::max)( ) ) {
+		if( f < -( daw::numeric_limits<Real>::max )( ) ) {
 			// -inf
 			return std::nullopt;
 		}
@@ -709,10 +709,10 @@ namespace daw::cxmath {
 			// Once c++20 use bit_cast
 			if( f == 0.0f ) {
 				return { 0, f }; // also matches -0.0f and gives wrong result
-			} else if( f > (daw::numeric_limits<float>::max)( ) ) {
+			} else if( f > ( daw::numeric_limits<float>::max )( ) ) {
 				// infinity
 				return { 0x7f80'0000, f };
-			} else if( f < -(daw::numeric_limits<float>::max)( ) ) {
+			} else if( f < -( daw::numeric_limits<float>::max )( ) ) {
 				// negative infinity
 				return { 0xff800000, f };
 			} else if( f != f ) {
@@ -1032,7 +1032,8 @@ namespace daw::cxmath {
 #if defined( DAW_CX_BIT_CAST )
 		return fp_classify( r ) == fp_classes::infinity;
 #else
-		return (r == daw::numeric_limits<Real>::infinity( )) | (r == -daw::numeric_limits<Real>::infinity( ));
+		return ( r == daw::numeric_limits<Real>::infinity( ) ) |
+		       ( r == -daw::numeric_limits<Real>::infinity( ) );
 #endif
 	}
 	static_assert( not is_inf( daw::numeric_limits<double>::quiet_NaN( ) ) );

--- a/include/daw/daw_cxmath.h
+++ b/include/daw/daw_cxmath.h
@@ -283,13 +283,13 @@ namespace daw::cxmath {
 		[[nodiscard]] constexpr Float pow2_impl2( intmax_t exp ) noexcept {
 			bool is_neg = exp < 0;
 			exp = is_neg ? -exp : exp;
-			auto const max_shft = daw::min(
+			auto const max_shft = (daw::min)(
 			  static_cast<size_t>( daw::numeric_limits<Float>::max_exponent10 ),
 			  ( sizeof( size_t ) * 8ULL ) );
 			Float result = 1.0;
 
 			while( static_cast<size_t>( exp ) >= max_shft ) {
-				result *= static_cast<Float>( daw::numeric_limits<size_t>::max( ) );
+				result *= static_cast<Float>( (daw::numeric_limits<size_t>::max)( ) );
 				exp -= max_shft;
 			}
 			if( exp > 0 ) {
@@ -321,7 +321,7 @@ namespace daw::cxmath {
 			exp = is_neg ? -exp : exp;
 
 			auto const max_spow =
-			  daw::min( daw::numeric_limits<Float>::max_exponent10,
+			  (daw::min)( daw::numeric_limits<Float>::max_exponent10,
 			            daw::numeric_limits<size_t>::digits10 );
 			Float result = 1.0;
 
@@ -539,11 +539,11 @@ namespace daw::cxmath {
 		if( f == 0.0f ) {
 			return static_cast<std::int32_t>( 0 );
 		}
-		if( f > daw::numeric_limits<Real>::max( ) ) {
+		if( f > (daw::numeric_limits<Real>::max)( ) ) {
 			// inf
 			return std::nullopt;
 		}
-		if( f < -daw::numeric_limits<Real>::max( ) ) {
+		if( f < -(daw::numeric_limits<Real>::max)( ) ) {
 			// -inf
 			return std::nullopt;
 		}
@@ -709,10 +709,10 @@ namespace daw::cxmath {
 			// Once c++20 use bit_cast
 			if( f == 0.0f ) {
 				return { 0, f }; // also matches -0.0f and gives wrong result
-			} else if( f > daw::numeric_limits<float>::max( ) ) {
+			} else if( f > (daw::numeric_limits<float>::max)( ) ) {
 				// infinity
 				return { 0x7f80'0000, f };
-			} else if( f < -daw::numeric_limits<float>::max( ) ) {
+			} else if( f < -(daw::numeric_limits<float>::max)( ) ) {
 				// negative infinity
 				return { 0xff800000, f };
 			} else if( f != f ) {

--- a/include/daw/daw_fixed_lookup.h
+++ b/include/daw/daw_fixed_lookup.h
@@ -60,7 +60,7 @@ namespace daw {
 		using value_t = daw::traits::root_type_t<Value>;
 		using hash_value_t = typename daw::generic_hash_t<HashSize>::hash_value_t;
 		static_assert(
-		  N <= (std::numeric_limits<hash_value_t>::max)( ),
+		  N <= ( std::numeric_limits<hash_value_t>::max )( ),
 		  "Cannot allocate more values than can be addressed by hash value" );
 
 		using reference = value_t &;
@@ -91,7 +91,7 @@ namespace daw {
 			auto const hash =
 			  daw::generic_hash<HashSize>( std::forward<KeyType>( key ) );
 			auto const divisor =
-			  (std::numeric_limits<hash_value_t>::max)( ) -
+			  ( std::numeric_limits<hash_value_t>::max )( ) -
 			  impl::fixed_lookup_sentinals::fixed_lookup_sentinals_size;
 			return ( hash % divisor ) +
 			       impl::fixed_lookup_sentinals::fixed_lookup_sentinals_size;

--- a/include/daw/daw_fixed_lookup.h
+++ b/include/daw/daw_fixed_lookup.h
@@ -60,7 +60,7 @@ namespace daw {
 		using value_t = daw::traits::root_type_t<Value>;
 		using hash_value_t = typename daw::generic_hash_t<HashSize>::hash_value_t;
 		static_assert(
-		  N <= std::numeric_limits<hash_value_t>::max( ),
+		  N <= (std::numeric_limits<hash_value_t>::max)( ),
 		  "Cannot allocate more values than can be addressed by hash value" );
 
 		using reference = value_t &;
@@ -91,7 +91,7 @@ namespace daw {
 			auto const hash =
 			  daw::generic_hash<HashSize>( std::forward<KeyType>( key ) );
 			auto const divisor =
-			  std::numeric_limits<hash_value_t>::max( ) -
+			  (std::numeric_limits<hash_value_t>::max)( ) -
 			  impl::fixed_lookup_sentinals::fixed_lookup_sentinals_size;
 			return ( hash % divisor ) +
 			       impl::fixed_lookup_sentinals::fixed_lookup_sentinals_size;

--- a/include/daw/daw_function_view.h
+++ b/include/daw/daw_function_view.h
@@ -39,7 +39,7 @@ namespace daw {
 			using fn_t = std::remove_reference_t<Func>;
 			if constexpr( std::is_pointer_v<fn_t> ) {
 				return { data_t{ f }, []( data_t const &d, Args... args ) -> Result {
-					        return (d.fp_storage)( std::move( args )... );
+					        return ( d.fp_storage )( std::move( args )... );
 				        } };
 			} else if constexpr( std::is_empty_v<fn_t> and
 			                     std::is_default_constructible_v<fn_t> ) {
@@ -50,8 +50,8 @@ namespace daw {
 			} else {
 				return { data_t{ DAW_BIT_CAST( ref_buffer_t, std::addressof( f ) ) },
 				         +[]( data_t const &d, Args... args ) -> Result {
-					         return (*DAW_BIT_CAST(
-					           fn_t const *, d.ref_storage ))( std::move( args )... );
+					         return ( *DAW_BIT_CAST( fn_t const *, d.ref_storage ) )(
+					           std::move( args )... );
 				         } };
 			}
 		}

--- a/include/daw/daw_graph.h
+++ b/include/daw/daw_graph.h
@@ -30,7 +30,7 @@ namespace daw {
 
 	class node_id_t {
 		static inline constexpr size_t const NO_ID =
-		  (std::numeric_limits<size_t>::max)( );
+		  ( std::numeric_limits<size_t>::max )( );
 		size_t m_value = NO_ID;
 
 		constexpr size_t value( ) const noexcept {

--- a/include/daw/daw_graph.h
+++ b/include/daw/daw_graph.h
@@ -30,7 +30,7 @@ namespace daw {
 
 	class node_id_t {
 		static inline constexpr size_t const NO_ID =
-		  std::numeric_limits<size_t>::max( );
+		  (std::numeric_limits<size_t>::max)( );
 		size_t m_value = NO_ID;
 
 		constexpr size_t value( ) const noexcept {

--- a/include/daw/daw_hash_table.h
+++ b/include/daw/daw_hash_table.h
@@ -388,7 +388,7 @@ namespace daw {
 			static const auto s_hash = []( auto &&k ) {
 				size_t result =
 				  ( daw::fnv1a_hash( std::forward<KeyType>( k ) ) %
-				    ( std::numeric_limits<size_t>::max( ) -
+				    ( (std::numeric_limits<std::size_t>::max)( ) -
 				      impl::hash_table_item<value_type>::SentinalsSize ) ) +
 				  impl::hash_table_item<value_type>::SentinalsSize; // Guarantee we
 				                                                    // cannot be zero
@@ -510,7 +510,7 @@ namespace daw {
 
 	public:
 		static size_t max_size( ) {
-			return static_cast<size_t>( std::numeric_limits<ptrdiff_t>::max( ) - 1 );
+			return static_cast<size_t>( (std::numeric_limits<std::ptrdiff_t>::max)( ) - 1 );
 		}
 
 		template<typename Key>

--- a/include/daw/daw_hash_table.h
+++ b/include/daw/daw_hash_table.h
@@ -388,7 +388,7 @@ namespace daw {
 			static const auto s_hash = []( auto &&k ) {
 				size_t result =
 				  ( daw::fnv1a_hash( std::forward<KeyType>( k ) ) %
-				    ( (std::numeric_limits<std::size_t>::max)( ) -
+				    ( ( std::numeric_limits<std::size_t>::max )( ) -
 				      impl::hash_table_item<value_type>::SentinalsSize ) ) +
 				  impl::hash_table_item<value_type>::SentinalsSize; // Guarantee we
 				                                                    // cannot be zero
@@ -510,7 +510,8 @@ namespace daw {
 
 	public:
 		static size_t max_size( ) {
-			return static_cast<size_t>( (std::numeric_limits<std::ptrdiff_t>::max)( ) - 1 );
+			return static_cast<size_t>(
+			  ( std::numeric_limits<std::ptrdiff_t>::max )( ) - 1 );
 		}
 
 		template<typename Key>

--- a/include/daw/daw_hash_table2.h
+++ b/include/daw/daw_hash_table2.h
@@ -28,18 +28,18 @@ namespace daw {
 		template<typename KeyType>
 		struct s_hash_fn_t {
 			constexpr size_t operator( )( KeyType const &k ) noexcept {
-				size_t result =
-				  ( daw::fnv1a_hash( k ) % ( (std::numeric_limits<std::size_t>::max)( ) -
-				                             impl::sentinals::sentinals_size ) ) +
-				  impl::sentinals::sentinals_size;
+				size_t result = ( daw::fnv1a_hash( k ) %
+				                  ( ( std::numeric_limits<std::size_t>::max )( ) -
+				                    impl::sentinals::sentinals_size ) ) +
+				                impl::sentinals::sentinals_size;
 				return result;
 			}
 
 			constexpr size_t operator( )( KeyType const *k ) noexcept {
-				size_t result =
-				  ( daw::fnv1a_hash( k ) % ( (std::numeric_limits<std::size_t>::max)( ) -
-				                             impl::sentinals::sentinals_size ) ) +
-				  impl::sentinals::sentinals_size;
+				size_t result = ( daw::fnv1a_hash( k ) %
+				                  ( ( std::numeric_limits<std::size_t>::max )( ) -
+				                    impl::sentinals::sentinals_size ) ) +
+				                impl::sentinals::sentinals_size;
 				return result;
 			}
 		};
@@ -71,7 +71,8 @@ namespace daw {
 		daw::heap_array<value_type> m_values;
 
 		static constexpr size_t max_size( ) noexcept {
-			return static_cast<size_t>( (std::numeric_limits<std::ptrdiff_t>::max)( ) - 1 );
+			return static_cast<size_t>(
+			  ( std::numeric_limits<std::ptrdiff_t>::max )( ) - 1 );
 		}
 
 		template<typename KeyType>
@@ -113,8 +114,8 @@ namespace daw {
 			auto const s_hash = scale_hash( hash, m_hashes.size( ) );
 			result.position = s_hash;
 			size_t removed_found =
-			  (std::numeric_limits<std::size_t>::max)( ); // Need a check and this will be
-			                                       // rare
+			  ( std::numeric_limits<std::size_t>::max )( ); // Need a check and this
+			                                                // will be rare
 			for( ; result.position != m_hashes.size( ); ++result.position ) {
 				if( m_hashes[result.position] == hash ) {
 					result.found = true;
@@ -144,7 +145,7 @@ namespace daw {
 					removed_found = result.position;
 				}
 			}
-			if( removed_found < (std::numeric_limits<std::size_t>::max)( ) ) {
+			if( removed_found < ( std::numeric_limits<std::size_t>::max )( ) ) {
 				result.lookup_cost = m_hashes.size( );
 				result.position = removed_found;
 				return result;

--- a/include/daw/daw_hash_table2.h
+++ b/include/daw/daw_hash_table2.h
@@ -29,7 +29,7 @@ namespace daw {
 		struct s_hash_fn_t {
 			constexpr size_t operator( )( KeyType const &k ) noexcept {
 				size_t result =
-				  ( daw::fnv1a_hash( k ) % ( std::numeric_limits<size_t>::max( ) -
+				  ( daw::fnv1a_hash( k ) % ( (std::numeric_limits<std::size_t>::max)( ) -
 				                             impl::sentinals::sentinals_size ) ) +
 				  impl::sentinals::sentinals_size;
 				return result;
@@ -37,7 +37,7 @@ namespace daw {
 
 			constexpr size_t operator( )( KeyType const *k ) noexcept {
 				size_t result =
-				  ( daw::fnv1a_hash( k ) % ( std::numeric_limits<size_t>::max( ) -
+				  ( daw::fnv1a_hash( k ) % ( (std::numeric_limits<std::size_t>::max)( ) -
 				                             impl::sentinals::sentinals_size ) ) +
 				  impl::sentinals::sentinals_size;
 				return result;
@@ -71,7 +71,7 @@ namespace daw {
 		daw::heap_array<value_type> m_values;
 
 		static constexpr size_t max_size( ) noexcept {
-			return static_cast<size_t>( std::numeric_limits<ptrdiff_t>::max( ) - 1 );
+			return static_cast<size_t>( (std::numeric_limits<std::ptrdiff_t>::max)( ) - 1 );
 		}
 
 		template<typename KeyType>
@@ -113,7 +113,7 @@ namespace daw {
 			auto const s_hash = scale_hash( hash, m_hashes.size( ) );
 			result.position = s_hash;
 			size_t removed_found =
-			  std::numeric_limits<size_t>::max( ); // Need a check and this will be
+			  (std::numeric_limits<std::size_t>::max)( ); // Need a check and this will be
 			                                       // rare
 			for( ; result.position != m_hashes.size( ); ++result.position ) {
 				if( m_hashes[result.position] == hash ) {
@@ -144,7 +144,7 @@ namespace daw {
 					removed_found = result.position;
 				}
 			}
-			if( removed_found < std::numeric_limits<size_t>::max( ) ) {
+			if( removed_found < (std::numeric_limits<std::size_t>::max)( ) ) {
 				result.lookup_cost = m_hashes.size( );
 				result.position = removed_found;
 				return result;

--- a/include/daw/daw_is_constant_evaluated.h
+++ b/include/daw/daw_is_constant_evaluated.h
@@ -26,7 +26,8 @@
 
 #define DAW_IS_CONSTANT_EVALUATED( ) __builtin_is_constant_evaluated( )
 
-#elif defined( __GNUC__ ) and not defined( __clang__ ) and __GNUC__ >= 9 and __GNUC_MINOR__ >= 1
+#elif defined( __GNUC__ ) and not defined( __clang__ ) and __GNUC__ >= 9 and   \
+  __GNUC_MINOR__ >= 1
 
 #define DAW_IS_CONSTANT_EVALUATED( ) __builtin_is_constant_evaluated( )
 

--- a/include/daw/daw_math.h
+++ b/include/daw/daw_math.h
@@ -8,10 +8,6 @@
 
 #pragma once
 
-#ifdef max
-#undef max
-#endif // max
-
 #include "cpp_17.h"
 #include "daw_algorithm.h"
 #include "daw_scope_guard.h"
@@ -142,7 +138,7 @@ namespace daw::math {
 	                          std::nullptr_t> = nullptr>
 	constexpr Result abs( SignedInteger v ) noexcept {
 		// This accounts for when negating the number is out of range
-		if( static_cast<intmax_t>( v ) == std::numeric_limits<intmax_t>::min( ) ) {
+		if( static_cast<intmax_t>( v ) == (std::numeric_limits<intmax_t>::min)( ) ) {
 			return pow2<Result>( bsizeof<intmax_t> - 1 );
 		}
 		if( v < 0 ) {
@@ -280,7 +276,7 @@ namespace daw::math {
 			return diff < ( epsilon * std::numeric_limits<T>::min_exponent );
 		}
 		// use relative error
-		return diff / daw::min( ( absA + absB ), std::numeric_limits<T>::max( ) ) <
+		return diff / (daw::min)( ( absA + absB ), (std::numeric_limits<T>::max)( ) ) <
 		       epsilon;
 	}
 #ifdef __clang__

--- a/include/daw/daw_math.h
+++ b/include/daw/daw_math.h
@@ -138,7 +138,8 @@ namespace daw::math {
 	                          std::nullptr_t> = nullptr>
 	constexpr Result abs( SignedInteger v ) noexcept {
 		// This accounts for when negating the number is out of range
-		if( static_cast<intmax_t>( v ) == (std::numeric_limits<intmax_t>::min)( ) ) {
+		if( static_cast<intmax_t>( v ) ==
+		    ( std::numeric_limits<intmax_t>::min )( ) ) {
 			return pow2<Result>( bsizeof<intmax_t> - 1 );
 		}
 		if( v < 0 ) {
@@ -276,7 +277,8 @@ namespace daw::math {
 			return diff < ( epsilon * std::numeric_limits<T>::min_exponent );
 		}
 		// use relative error
-		return diff / (daw::min)( ( absA + absB ), (std::numeric_limits<T>::max)( ) ) <
+		return diff / ( daw::min )( ( absA + absB ),
+		                            ( std::numeric_limits<T>::max )( ) ) <
 		       epsilon;
 	}
 #ifdef __clang__

--- a/include/daw/daw_min_perfect_hash.h
+++ b/include/daw/daw_min_perfect_hash.h
@@ -138,8 +138,9 @@ namespace daw {
 		using hash_result = daw::remove_cvref_t<std::invoke_result_t<Hasher, Key>>;
 		using salt_type = intmax_t;
 		static size_t constexpr m_data_size = mph_impl::next_pow2<N>( );
-		static_assert( m_data_size <= static_cast<size_t>(
-		                                (std::numeric_limits<salt_type>::max)( ) ) );
+		static_assert(
+		  m_data_size <=
+		  static_cast<size_t>( ( std::numeric_limits<salt_type>::max )( ) ) );
 
 		/***
 		 * Construct a perfect_hash_table from a range of pair like items that have

--- a/include/daw/daw_min_perfect_hash.h
+++ b/include/daw/daw_min_perfect_hash.h
@@ -139,7 +139,7 @@ namespace daw {
 		using salt_type = intmax_t;
 		static size_t constexpr m_data_size = mph_impl::next_pow2<N>( );
 		static_assert( m_data_size <= static_cast<size_t>(
-		                                std::numeric_limits<salt_type>::max( ) ) );
+		                                (std::numeric_limits<salt_type>::max)( ) ) );
 
 		/***
 		 * Construct a perfect_hash_table from a range of pair like items that have

--- a/include/daw/daw_move.h
+++ b/include/daw/daw_move.h
@@ -41,4 +41,3 @@ namespace daw {
 #ifndef DAW_FWD2
 #define DAW_FWD2( Type, Value ) static_cast<Type &&>( Value )
 #endif
-

--- a/include/daw/daw_random.h
+++ b/include/daw/daw_random.h
@@ -39,8 +39,8 @@ namespace daw {
 
 	template<typename IntType>
 	inline IntType randint( ) {
-		return randint<IntType>( (std::numeric_limits<IntType>::min)( ),
-		                         (std::numeric_limits<IntType>::max)( ) );
+		return randint<IntType>( ( std::numeric_limits<IntType>::min )( ),
+		                         ( std::numeric_limits<IntType>::max )( ) );
 	}
 
 	inline void reseed( ) {
@@ -85,8 +85,8 @@ namespace daw {
 	template<typename IntType, typename Result = std::vector<IntType>>
 	inline Result
 	make_random_data( size_t count,
-	                  IntType a = (std::numeric_limits<IntType>::min)( ),
-	                  IntType b = (std::numeric_limits<IntType>::max)( ) ) {
+	                  IntType a = ( std::numeric_limits<IntType>::min )( ),
+	                  IntType b = ( std::numeric_limits<IntType>::max )( ) ) {
 
 		static_assert( std::is_integral_v<IntType>,
 		               "IntType must be a valid integral type" );

--- a/include/daw/daw_random.h
+++ b/include/daw/daw_random.h
@@ -39,8 +39,8 @@ namespace daw {
 
 	template<typename IntType>
 	inline IntType randint( ) {
-		return randint<IntType>( std::numeric_limits<IntType>::min( ),
-		                         std::numeric_limits<IntType>::max( ) );
+		return randint<IntType>( (std::numeric_limits<IntType>::min)( ),
+		                         (std::numeric_limits<IntType>::max)( ) );
 	}
 
 	inline void reseed( ) {
@@ -85,8 +85,8 @@ namespace daw {
 	template<typename IntType, typename Result = std::vector<IntType>>
 	inline Result
 	make_random_data( size_t count,
-	                  IntType a = std::numeric_limits<IntType>::min( ),
-	                  IntType b = std::numeric_limits<IntType>::max( ) ) {
+	                  IntType a = (std::numeric_limits<IntType>::min)( ),
+	                  IntType b = (std::numeric_limits<IntType>::max)( ) ) {
 
 		static_assert( std::is_integral_v<IntType>,
 		               "IntType must be a valid integral type" );

--- a/include/daw/daw_scope_guard.h
+++ b/include/daw/daw_scope_guard.h
@@ -109,4 +109,3 @@ namespace daw {
 	template<typename Handler>
 	on_exit_success( Handler ) -> on_exit_success<Handler>;
 } // namespace daw
-

--- a/include/daw/daw_span.h
+++ b/include/daw/daw_span.h
@@ -199,14 +199,14 @@ namespace daw {
 			return true;
 		}
 
-		constexpr span
-		subspan( size_type pos = 0,
-		         size_type count = (std::numeric_limits<size_type>::max)( ) ) const {
+		constexpr span subspan(
+		  size_type pos = 0,
+		  size_type count = ( std::numeric_limits<size_type>::max )( ) ) const {
 
 			daw::exception::precondition_check<std::out_of_range>(
 			  pos < size( ), "Attempt to access span past end" );
 
-			count = (daw::min)( count, size( ) - pos );
+			count = ( daw::min )( count, size( ) - pos );
 			return { data( ) + pos, count };
 		}
 	};
@@ -463,23 +463,23 @@ namespace daw {
 
 		constexpr span
 		subspan( size_type pos = 0,
-		         size_type count = (std::numeric_limits<size_type>::max)( ) ) {
+		         size_type count = ( std::numeric_limits<size_type>::max )( ) ) {
 
 			daw::exception::precondition_check<std::out_of_range>(
 			  pos < size( ), "Attempt to access span past end" );
 
-			count = (daw::min)( count, size( ) - pos );
+			count = ( daw::min )( count, size( ) - pos );
 			return { data( ) + pos, count };
 		}
 
-		constexpr span
-		subspan( size_type pos = 0,
-		         size_type count = (std::numeric_limits<size_type>::max)( ) ) const {
+		constexpr span subspan(
+		  size_type pos = 0,
+		  size_type count = ( std::numeric_limits<size_type>::max )( ) ) const {
 
 			daw::exception::precondition_check<std::out_of_range>(
 			  pos < size( ), "Attempt to access span past end" );
 
-			count = (daw::min)( count, size( ) - pos );
+			count = ( daw::min )( count, size( ) - pos );
 			return { data( ) + pos, count };
 		}
 	};

--- a/include/daw/daw_span.h
+++ b/include/daw/daw_span.h
@@ -201,12 +201,12 @@ namespace daw {
 
 		constexpr span
 		subspan( size_type pos = 0,
-		         size_type count = std::numeric_limits<size_type>::max( ) ) const {
+		         size_type count = (std::numeric_limits<size_type>::max)( ) ) const {
 
 			daw::exception::precondition_check<std::out_of_range>(
 			  pos < size( ), "Attempt to access span past end" );
 
-			count = daw::min( count, size( ) - pos );
+			count = (daw::min)( count, size( ) - pos );
 			return { data( ) + pos, count };
 		}
 	};
@@ -463,23 +463,23 @@ namespace daw {
 
 		constexpr span
 		subspan( size_type pos = 0,
-		         size_type count = std::numeric_limits<size_type>::max( ) ) {
+		         size_type count = (std::numeric_limits<size_type>::max)( ) ) {
 
 			daw::exception::precondition_check<std::out_of_range>(
 			  pos < size( ), "Attempt to access span past end" );
 
-			count = daw::min( count, size( ) - pos );
+			count = (daw::min)( count, size( ) - pos );
 			return { data( ) + pos, count };
 		}
 
 		constexpr span
 		subspan( size_type pos = 0,
-		         size_type count = std::numeric_limits<size_type>::max( ) ) const {
+		         size_type count = (std::numeric_limits<size_type>::max)( ) ) const {
 
 			daw::exception::precondition_check<std::out_of_range>(
 			  pos < size( ), "Attempt to access span past end" );
 
-			count = daw::min( count, size( ) - pos );
+			count = (daw::min)( count, size( ) - pos );
 			return { data( ) + pos, count };
 		}
 	};

--- a/include/daw/daw_static_bitset.h
+++ b/include/daw/daw_static_bitset.h
@@ -92,7 +92,7 @@ namespace daw {
 				bw = bsizeof<value_t> - bw;
 			}
 			if( bw == 0 ) {
-				return (std::numeric_limits<value_t>::max)( );
+				return ( std::numeric_limits<value_t>::max )( );
 			}
 			return daw::mask_msb<value_t>( bw );
 		}
@@ -342,7 +342,7 @@ namespace daw {
 		template<size_t BitWidthRhs>
 		constexpr static_bitset
 		operator|=( static_bitset<BitWidthRhs> const &rhs ) noexcept {
-			size_t const SZ = (std::min)( m_data.size( ), rhs.m_data.size( ) );
+			size_t const SZ = ( std::min )( m_data.size( ), rhs.m_data.size( ) );
 			for( size_t n = 0; n < SZ; ++n ) {
 				m_data[n] |= rhs.m_data[n];
 			}
@@ -350,7 +350,7 @@ namespace daw {
 		}
 
 		template<size_t BitWidthRhs>
-		constexpr static_bitset<(std::max)( BitWidth, BitWidthRhs )>
+		constexpr static_bitset<( std::max )( BitWidth, BitWidthRhs )>
 		operator|( static_bitset<BitWidthRhs> const &rhs ) const noexcept {
 			if constexpr( BitWidth >= BitWidthRhs ) {
 				static_bitset result( *this );
@@ -366,7 +366,7 @@ namespace daw {
 		template<size_t BitWidthRhs>
 		constexpr static_bitset &
 		operator&=( static_bitset<BitWidthRhs> const &rhs ) noexcept {
-			size_t const SZ = (std::min)( m_data.size( ), rhs.m_data.size( ) );
+			size_t const SZ = ( std::min )( m_data.size( ), rhs.m_data.size( ) );
 			size_t n = 0;
 			for( ; n < SZ; ++n ) {
 				m_data[n] &= rhs.m_data[n];
@@ -386,9 +386,9 @@ namespace daw {
 		}
 
 		template<size_t BitWidthRhs>
-		constexpr static_bitset<(std::max)( BitWidth, BitWidthRhs )>
+		constexpr static_bitset<( std::max )( BitWidth, BitWidthRhs )>
 		operator^( static_bitset<BitWidthRhs> const &rhs ) const noexcept {
-			static_bitset<(std::max)( BitWidth, BitWidthRhs )> result{ };
+			static_bitset<( std::max )( BitWidth, BitWidthRhs )> result{ };
 			size_t n = 0;
 			for( ; n < m_data.size( ) and n < rhs.m_data.size( ); ++n ) {
 				result.m_data[n] = m_data[n] ^ rhs.m_data[n];
@@ -414,7 +414,7 @@ namespace daw {
 		template<size_t BitWidthRhs>
 		constexpr bool
 		operator==( static_bitset<BitWidthRhs> const &rhs ) const noexcept {
-			size_t const last = (std::min)( m_data.size( ), rhs.m_data.size( ) );
+			size_t const last = ( std::min )( m_data.size( ), rhs.m_data.size( ) );
 			size_t n = 0;
 			for( ; n < last; ++n ) {
 				if( m_data[n] != rhs.m_data[n] ) {
@@ -437,7 +437,7 @@ namespace daw {
 		template<size_t BitWidthRhs>
 		constexpr bool
 		operator!=( static_bitset<BitWidthRhs> const &rhs ) const noexcept {
-			size_t const last = (std::min)( m_data.size( ), rhs.m_data.size( ) );
+			size_t const last = ( std::min )( m_data.size( ), rhs.m_data.size( ) );
 			size_t n = 0;
 			for( ; n < last; ++n ) {
 				if( m_data[n] != rhs.m_data[n] ) {

--- a/include/daw/daw_static_bitset.h
+++ b/include/daw/daw_static_bitset.h
@@ -92,7 +92,7 @@ namespace daw {
 				bw = bsizeof<value_t> - bw;
 			}
 			if( bw == 0 ) {
-				return std::numeric_limits<value_t>::max( );
+				return (std::numeric_limits<value_t>::max)( );
 			}
 			return daw::mask_msb<value_t>( bw );
 		}
@@ -342,7 +342,7 @@ namespace daw {
 		template<size_t BitWidthRhs>
 		constexpr static_bitset
 		operator|=( static_bitset<BitWidthRhs> const &rhs ) noexcept {
-			size_t const SZ = std::min( m_data.size( ), rhs.m_data.size( ) );
+			size_t const SZ = (std::min)( m_data.size( ), rhs.m_data.size( ) );
 			for( size_t n = 0; n < SZ; ++n ) {
 				m_data[n] |= rhs.m_data[n];
 			}
@@ -350,7 +350,7 @@ namespace daw {
 		}
 
 		template<size_t BitWidthRhs>
-		constexpr static_bitset<std::max( BitWidth, BitWidthRhs )>
+		constexpr static_bitset<(std::max)( BitWidth, BitWidthRhs )>
 		operator|( static_bitset<BitWidthRhs> const &rhs ) const noexcept {
 			if constexpr( BitWidth >= BitWidthRhs ) {
 				static_bitset result( *this );
@@ -366,7 +366,7 @@ namespace daw {
 		template<size_t BitWidthRhs>
 		constexpr static_bitset &
 		operator&=( static_bitset<BitWidthRhs> const &rhs ) noexcept {
-			size_t const SZ = std::min( m_data.size( ), rhs.m_data.size( ) );
+			size_t const SZ = (std::min)( m_data.size( ), rhs.m_data.size( ) );
 			size_t n = 0;
 			for( ; n < SZ; ++n ) {
 				m_data[n] &= rhs.m_data[n];
@@ -386,9 +386,9 @@ namespace daw {
 		}
 
 		template<size_t BitWidthRhs>
-		constexpr static_bitset<std::max( BitWidth, BitWidthRhs )>
+		constexpr static_bitset<(std::max)( BitWidth, BitWidthRhs )>
 		operator^( static_bitset<BitWidthRhs> const &rhs ) const noexcept {
-			static_bitset<std::max( BitWidth, BitWidthRhs )> result{ };
+			static_bitset<(std::max)( BitWidth, BitWidthRhs )> result{ };
 			size_t n = 0;
 			for( ; n < m_data.size( ) and n < rhs.m_data.size( ); ++n ) {
 				result.m_data[n] = m_data[n] ^ rhs.m_data[n];
@@ -414,7 +414,7 @@ namespace daw {
 		template<size_t BitWidthRhs>
 		constexpr bool
 		operator==( static_bitset<BitWidthRhs> const &rhs ) const noexcept {
-			size_t const last = std::min( m_data.size( ), rhs.m_data.size( ) );
+			size_t const last = (std::min)( m_data.size( ), rhs.m_data.size( ) );
 			size_t n = 0;
 			for( ; n < last; ++n ) {
 				if( m_data[n] != rhs.m_data[n] ) {
@@ -437,7 +437,7 @@ namespace daw {
 		template<size_t BitWidthRhs>
 		constexpr bool
 		operator!=( static_bitset<BitWidthRhs> const &rhs ) const noexcept {
-			size_t const last = std::min( m_data.size( ), rhs.m_data.size( ) );
+			size_t const last = (std::min)( m_data.size( ), rhs.m_data.size( ) );
 			size_t n = 0;
 			for( ; n < last; ++n ) {
 				if( m_data[n] != rhs.m_data[n] ) {

--- a/include/daw/daw_string_view.h
+++ b/include/daw/daw_string_view.h
@@ -176,7 +176,7 @@ namespace daw {
 
 	public:
 		static constexpr size_type const npos =
-		  std::numeric_limits<size_type>::max( );
+		  (std::numeric_limits<size_type>::max)( );
 
 		// constructors
 		constexpr basic_string_view( ) noexcept = default;
@@ -200,7 +200,7 @@ namespace daw {
 		                             size_type count ) noexcept
 		  : m_first( sv.begin( ) )
 		  , m_last( make_last<BoundsType>( sv.begin( ),
-		                                   std::min( sv.size( ), count ) ) ) {}
+		                                   (std::min)( sv.size( ), count ) ) ) {}
 
 		template<std::size_t N>
 		constexpr basic_string_view( CharT const ( &cstr )[N] ) noexcept
@@ -381,7 +381,7 @@ namespace daw {
 		}
 
 		constexpr void remove_prefix( size_type n ) {
-			dec_front<BoundsType>( std::min( n, size( ) ) );
+			dec_front<BoundsType>( (std::min)( n, size( ) ) );
 		}
 
 		constexpr void remove_prefix( ) {
@@ -389,7 +389,7 @@ namespace daw {
 		}
 
 		constexpr void remove_suffix( size_type n ) {
-			dec_back<BoundsType>( std::min( n, size( ) ) );
+			dec_back<BoundsType>( (std::min)( n, size( ) ) );
 		}
 
 		constexpr void remove_suffix( ) {
@@ -458,7 +458,7 @@ namespace daw {
 		/// @param count number of characters to remove and return
 		/// @return a substr of size count ending at end of string_view
 		[[nodiscard]] constexpr basic_string_view pop_back( std::size_t count ) {
-			count = std::min( count, size( ) );
+			count = (std::min)( count, size( ) );
 			basic_string_view result = substr( size( ) - count, npos );
 			remove_suffix( count );
 			return result;
@@ -564,7 +564,7 @@ namespace daw {
 			daw::exception::precondition_check<std::out_of_range>(
 			  pos <= size( ), "Attempt to access basic_string_view past end" );
 
-			size_type const rlen = std::min( count, size( ) - pos );
+			size_type const rlen = (std::min)( count, size( ) - pos );
 			if( rlen > 0 ) {
 				auto const f =
 				  std::next( begin( ), static_cast<difference_type>( pos ) );
@@ -579,7 +579,7 @@ namespace daw {
 			daw::exception::precondition_check<std::out_of_range>(
 			  pos <= size( ), "Attempt to access basic_string_view past end" );
 			auto const rcount =
-			  static_cast<size_type>( std::min( count, size( ) - pos ) );
+			  static_cast<size_type>( (std::min)( count, size( ) - pos ) );
 			return { m_first + pos, m_first + pos + rcount };
 		}
 
@@ -605,7 +605,7 @@ namespace daw {
 			};
 
 			auto cmp = str_compare( lhs.data( ), rhs.data( ),
-			                        std::min( lhs.size( ), rhs.size( ) ) );
+			                        (std::min)( lhs.size( ), rhs.size( ) ) );
 			if( cmp == 0 ) {
 				if( lhs.size( ) < rhs.size( ) ) {
 					return -1;
@@ -708,7 +708,7 @@ namespace daw {
 			if( size( ) < v.size( ) ) {
 				return npos;
 			}
-			pos = std::min( pos, size( ) - v.size( ) );
+			pos = (std::min)( pos, size( ) - v.size( ) );
 			if( v.empty( ) ) {
 				return pos;
 			}
@@ -1562,7 +1562,7 @@ namespace daw {
 		std::vector<daw::basic_string_view<CharT, Bounds>> v{ };
 		auto last_pos = str.cbegin( );
 		while( !str.empty( ) ) {
-			auto sz = std::min( str.size( ), str.find_first_of_if( pred ) );
+			auto sz = (std::min)( str.size( ), str.find_first_of_if( pred ) );
 			v.emplace_back( last_pos, sz );
 			if( sz == str.npos ) {
 				break;

--- a/include/daw/daw_string_view.h
+++ b/include/daw/daw_string_view.h
@@ -176,7 +176,7 @@ namespace daw {
 
 	public:
 		static constexpr size_type const npos =
-		  (std::numeric_limits<size_type>::max)( );
+		  ( std::numeric_limits<size_type>::max )( );
 
 		// constructors
 		constexpr basic_string_view( ) noexcept = default;
@@ -200,7 +200,7 @@ namespace daw {
 		                             size_type count ) noexcept
 		  : m_first( sv.begin( ) )
 		  , m_last( make_last<BoundsType>( sv.begin( ),
-		                                   (std::min)( sv.size( ), count ) ) ) {}
+		                                   ( std::min )( sv.size( ), count ) ) ) {}
 
 		template<std::size_t N>
 		constexpr basic_string_view( CharT const ( &cstr )[N] ) noexcept
@@ -381,7 +381,7 @@ namespace daw {
 		}
 
 		constexpr void remove_prefix( size_type n ) {
-			dec_front<BoundsType>( (std::min)( n, size( ) ) );
+			dec_front<BoundsType>( ( std::min )( n, size( ) ) );
 		}
 
 		constexpr void remove_prefix( ) {
@@ -389,7 +389,7 @@ namespace daw {
 		}
 
 		constexpr void remove_suffix( size_type n ) {
-			dec_back<BoundsType>( (std::min)( n, size( ) ) );
+			dec_back<BoundsType>( ( std::min )( n, size( ) ) );
 		}
 
 		constexpr void remove_suffix( ) {
@@ -458,7 +458,7 @@ namespace daw {
 		/// @param count number of characters to remove and return
 		/// @return a substr of size count ending at end of string_view
 		[[nodiscard]] constexpr basic_string_view pop_back( std::size_t count ) {
-			count = (std::min)( count, size( ) );
+			count = ( std::min )( count, size( ) );
 			basic_string_view result = substr( size( ) - count, npos );
 			remove_suffix( count );
 			return result;
@@ -564,7 +564,7 @@ namespace daw {
 			daw::exception::precondition_check<std::out_of_range>(
 			  pos <= size( ), "Attempt to access basic_string_view past end" );
 
-			size_type const rlen = (std::min)( count, size( ) - pos );
+			size_type const rlen = ( std::min )( count, size( ) - pos );
 			if( rlen > 0 ) {
 				auto const f =
 				  std::next( begin( ), static_cast<difference_type>( pos ) );
@@ -579,7 +579,7 @@ namespace daw {
 			daw::exception::precondition_check<std::out_of_range>(
 			  pos <= size( ), "Attempt to access basic_string_view past end" );
 			auto const rcount =
-			  static_cast<size_type>( (std::min)( count, size( ) - pos ) );
+			  static_cast<size_type>( ( std::min )( count, size( ) - pos ) );
 			return { m_first + pos, m_first + pos + rcount };
 		}
 
@@ -605,7 +605,7 @@ namespace daw {
 			};
 
 			auto cmp = str_compare( lhs.data( ), rhs.data( ),
-			                        (std::min)( lhs.size( ), rhs.size( ) ) );
+			                        ( std::min )( lhs.size( ), rhs.size( ) ) );
 			if( cmp == 0 ) {
 				if( lhs.size( ) < rhs.size( ) ) {
 					return -1;
@@ -708,7 +708,7 @@ namespace daw {
 			if( size( ) < v.size( ) ) {
 				return npos;
 			}
-			pos = (std::min)( pos, size( ) - v.size( ) );
+			pos = ( std::min )( pos, size( ) - v.size( ) );
 			if( v.empty( ) ) {
 				return pos;
 			}
@@ -1562,7 +1562,7 @@ namespace daw {
 		std::vector<daw::basic_string_view<CharT, Bounds>> v{ };
 		auto last_pos = str.cbegin( );
 		while( !str.empty( ) ) {
-			auto sz = (std::min)( str.size( ), str.find_first_of_if( pred ) );
+			auto sz = ( std::min )( str.size( ), str.find_first_of_if( pred ) );
 			v.emplace_back( last_pos, sz );
 			if( sz == str.npos ) {
 				break;

--- a/include/daw/daw_traits.h
+++ b/include/daw/daw_traits.h
@@ -933,7 +933,7 @@ namespace daw::traits {
 			using TpL = typename Lhs::class_template_parameters;
 			using TpR = typename Rhs::class_template_parameters;
 			constexpr std::size_t Max =
-			  std::min( pack_size_v<TpL>, pack_size_v<TpL> );
+			  (std::min)( pack_size_v<TpL>, pack_size_v<TpL> );
 			return find_first_mismatch<StartIdx>(
 			  static_cast<TpL *>( nullptr ), static_cast<TpR *>( nullptr ),
 			  std::make_index_sequence<Max - StartIdx>{ }, Max );

--- a/include/daw/daw_traits.h
+++ b/include/daw/daw_traits.h
@@ -933,7 +933,7 @@ namespace daw::traits {
 			using TpL = typename Lhs::class_template_parameters;
 			using TpR = typename Rhs::class_template_parameters;
 			constexpr std::size_t Max =
-			  (std::min)( pack_size_v<TpL>, pack_size_v<TpL> );
+			  ( std::min )( pack_size_v<TpL>, pack_size_v<TpL> );
 			return find_first_mismatch<StartIdx>(
 			  static_cast<TpL *>( nullptr ), static_cast<TpR *>( nullptr ),
 			  std::make_index_sequence<Max - StartIdx>{ }, Max );
@@ -1079,6 +1079,4 @@ namespace daw {
 	expander( Ts... ) -> expander<Ts...>; // no warnings about intent to use CTAD
 } // namespace daw
 
-#define DAW_TYPEOF(...) daw::remove_cvref_t<decltype(__VA_ARGS__)>
-
-
+#define DAW_TYPEOF( ... ) daw::remove_cvref_t<decltype( __VA_ARGS__ )>

--- a/include/daw/daw_tuple_helper.h
+++ b/include/daw/daw_tuple_helper.h
@@ -373,15 +373,15 @@ namespace daw {
 		}
 
 		template<typename... Ts>
-		constexpr auto (min)( std::tuple<Ts...> const &a,
-		                    std::tuple<Ts...> const &b ) {
+		constexpr auto( min )( std::tuple<Ts...> const &a,
+		                       std::tuple<Ts...> const &b ) {
 			return operators::tuple_details::apply_tuple_tuple(
 			  a, b, daw::tuple::tuple_details::min_t::get( ) );
 		}
 
 		template<typename... Ts>
-		constexpr auto (max)( std::tuple<Ts...> const &a,
-		                    std::tuple<Ts...> const &b ) {
+		constexpr auto( max )( std::tuple<Ts...> const &a,
+		                       std::tuple<Ts...> const &b ) {
 			return operators::tuple_details::apply_tuple_tuple(
 			  a, b, daw::tuple::tuple_details::max_t::get( ) );
 		}

--- a/include/daw/daw_tuple_helper.h
+++ b/include/daw/daw_tuple_helper.h
@@ -83,7 +83,7 @@ namespace daw {
 				constexpr void operator( )( Result &result, A const &a,
 				                            B const &b ) const {
 					using daw::min;
-					result = min( a, b );
+					result = (min)( a, b );
 				}
 
 				static min_t const &get( ) noexcept {
@@ -97,7 +97,7 @@ namespace daw {
 				constexpr void operator( )( Result &result, A const &a,
 				                            B const &b ) const {
 					using daw::max;
-					result = max( a, b );
+					result = (max)( a, b );
 				}
 
 				static max_t const &get( ) noexcept {
@@ -373,14 +373,14 @@ namespace daw {
 		}
 
 		template<typename... Ts>
-		constexpr auto min( std::tuple<Ts...> const &a,
+		constexpr auto (min)( std::tuple<Ts...> const &a,
 		                    std::tuple<Ts...> const &b ) {
 			return operators::tuple_details::apply_tuple_tuple(
 			  a, b, daw::tuple::tuple_details::min_t::get( ) );
 		}
 
 		template<typename... Ts>
-		constexpr auto max( std::tuple<Ts...> const &a,
+		constexpr auto (max)( std::tuple<Ts...> const &a,
 		                    std::tuple<Ts...> const &b ) {
 			return operators::tuple_details::apply_tuple_tuple(
 			  a, b, daw::tuple::tuple_details::max_t::get( ) );

--- a/include/daw/daw_uint_buffer.h
+++ b/include/daw/daw_uint_buffer.h
@@ -3050,7 +3050,7 @@ namespace std {
 		// static constexpr bool traps = true;
 		static constexpr bool tinyness_before = false;
 
-		static constexpr daw::UInt64 (min)( ) noexcept {
+		static constexpr daw::UInt64( min )( ) noexcept {
 			return daw::UInt64( );
 		}
 
@@ -3058,9 +3058,9 @@ namespace std {
 			return daw::UInt64( );
 		}
 
-		static constexpr daw::UInt64 (max)( ) noexcept {
+		static constexpr daw::UInt64( max )( ) noexcept {
 			return static_cast<daw::UInt64>(
-			  (std::numeric_limits<std::uint64_t>::max)( ) );
+			  ( std::numeric_limits<std::uint64_t>::max )( ) );
 		}
 
 		static constexpr daw::UInt64 epsilon( ) noexcept {
@@ -3117,7 +3117,7 @@ namespace std {
 		// static constexpr bool traps = true;
 		static constexpr bool tinyness_before = false;
 
-		static constexpr daw::UInt32 (min)( ) noexcept {
+		static constexpr daw::UInt32( min )( ) noexcept {
 			return daw::UInt32( );
 		}
 
@@ -3125,9 +3125,9 @@ namespace std {
 			return daw::UInt32( );
 		}
 
-		static constexpr daw::UInt32 (max)( ) noexcept {
+		static constexpr daw::UInt32( max )( ) noexcept {
 			return static_cast<daw::UInt32>(
-			  (std::numeric_limits<std::uint32_t>::max)( ) );
+			  ( std::numeric_limits<std::uint32_t>::max )( ) );
 		}
 
 		static constexpr daw::UInt32 epsilon( ) noexcept {
@@ -3184,7 +3184,7 @@ namespace std {
 		// static constexpr bool traps = true;
 		static constexpr bool tinyness_before = false;
 
-		static constexpr daw::UInt16 (min)( ) noexcept {
+		static constexpr daw::UInt16( min )( ) noexcept {
 			return daw::UInt16( );
 		}
 
@@ -3192,9 +3192,9 @@ namespace std {
 			return daw::UInt16( );
 		}
 
-		static constexpr daw::UInt16 (max)( ) noexcept {
+		static constexpr daw::UInt16( max )( ) noexcept {
 			return static_cast<daw::UInt16>(
-			  (std::numeric_limits<std::uint16_t>::max)( ) );
+			  ( std::numeric_limits<std::uint16_t>::max )( ) );
 		}
 
 		static constexpr daw::UInt16 epsilon( ) noexcept {
@@ -3251,7 +3251,7 @@ namespace std {
 		// static constexpr bool traps = true;
 		static constexpr bool tinyness_before = false;
 
-		static constexpr daw::UInt8 (min)( ) noexcept {
+		static constexpr daw::UInt8( min )( ) noexcept {
 			return daw::UInt8( );
 		}
 
@@ -3259,9 +3259,9 @@ namespace std {
 			return daw::UInt8( );
 		}
 
-		static constexpr daw::UInt8 (max)( ) noexcept {
+		static constexpr daw::UInt8( max )( ) noexcept {
 			return static_cast<daw::UInt8>(
-			  (std::numeric_limits<std::uint8_t>::max)( ) );
+			  ( std::numeric_limits<std::uint8_t>::max )( ) );
 		}
 
 		static constexpr daw::UInt8 epsilon( ) noexcept {
@@ -3297,19 +3297,19 @@ namespace daw {
 
 	constexpr UInt32 operator"" _u32( unsigned long long value ) {
 		assert( ( value <= static_cast<unsigned long long>(
-		                     (daw::numeric_limits<std::uint32_t>::max)( ) ) ) );
+		                     ( daw::numeric_limits<std::uint32_t>::max )( ) ) ) );
 		return static_cast<UInt32>( value );
 	}
 
 	constexpr UInt16 operator"" _u16( unsigned long long value ) {
 		assert( ( value < static_cast<unsigned long long>(
-		                    (std::numeric_limits<std::uint16_t>::max)( ) ) ) );
+		                    ( std::numeric_limits<std::uint16_t>::max )( ) ) ) );
 		return static_cast<UInt16>( value );
 	}
 
 	constexpr UInt8 operator"" _u8( unsigned long long value ) {
 		assert( ( value < static_cast<unsigned long long>(
-		                    (std::numeric_limits<std::uint8_t>::max)( ) ) ) );
+		                    ( std::numeric_limits<std::uint8_t>::max )( ) ) ) );
 		return static_cast<UInt8>( value );
 	}
 } // namespace daw

--- a/include/daw/daw_uint_buffer.h
+++ b/include/daw/daw_uint_buffer.h
@@ -3050,7 +3050,7 @@ namespace std {
 		// static constexpr bool traps = true;
 		static constexpr bool tinyness_before = false;
 
-		static constexpr daw::UInt64 min( ) noexcept {
+		static constexpr daw::UInt64 (min)( ) noexcept {
 			return daw::UInt64( );
 		}
 
@@ -3058,9 +3058,9 @@ namespace std {
 			return daw::UInt64( );
 		}
 
-		static constexpr daw::UInt64 max( ) noexcept {
+		static constexpr daw::UInt64 (max)( ) noexcept {
 			return static_cast<daw::UInt64>(
-			  std::numeric_limits<std::uint64_t>::max( ) );
+			  (std::numeric_limits<std::uint64_t>::max)( ) );
 		}
 
 		static constexpr daw::UInt64 epsilon( ) noexcept {
@@ -3117,7 +3117,7 @@ namespace std {
 		// static constexpr bool traps = true;
 		static constexpr bool tinyness_before = false;
 
-		static constexpr daw::UInt32 min( ) noexcept {
+		static constexpr daw::UInt32 (min)( ) noexcept {
 			return daw::UInt32( );
 		}
 
@@ -3125,9 +3125,9 @@ namespace std {
 			return daw::UInt32( );
 		}
 
-		static constexpr daw::UInt32 max( ) noexcept {
+		static constexpr daw::UInt32 (max)( ) noexcept {
 			return static_cast<daw::UInt32>(
-			  std::numeric_limits<std::uint32_t>::max( ) );
+			  (std::numeric_limits<std::uint32_t>::max)( ) );
 		}
 
 		static constexpr daw::UInt32 epsilon( ) noexcept {
@@ -3184,7 +3184,7 @@ namespace std {
 		// static constexpr bool traps = true;
 		static constexpr bool tinyness_before = false;
 
-		static constexpr daw::UInt16 min( ) noexcept {
+		static constexpr daw::UInt16 (min)( ) noexcept {
 			return daw::UInt16( );
 		}
 
@@ -3192,9 +3192,9 @@ namespace std {
 			return daw::UInt16( );
 		}
 
-		static constexpr daw::UInt16 max( ) noexcept {
+		static constexpr daw::UInt16 (max)( ) noexcept {
 			return static_cast<daw::UInt16>(
-			  std::numeric_limits<std::uint16_t>::max( ) );
+			  (std::numeric_limits<std::uint16_t>::max)( ) );
 		}
 
 		static constexpr daw::UInt16 epsilon( ) noexcept {
@@ -3251,7 +3251,7 @@ namespace std {
 		// static constexpr bool traps = true;
 		static constexpr bool tinyness_before = false;
 
-		static constexpr daw::UInt8 min( ) noexcept {
+		static constexpr daw::UInt8 (min)( ) noexcept {
 			return daw::UInt8( );
 		}
 
@@ -3259,9 +3259,9 @@ namespace std {
 			return daw::UInt8( );
 		}
 
-		static constexpr daw::UInt8 max( ) noexcept {
+		static constexpr daw::UInt8 (max)( ) noexcept {
 			return static_cast<daw::UInt8>(
-			  std::numeric_limits<std::uint8_t>::max( ) );
+			  (std::numeric_limits<std::uint8_t>::max)( ) );
 		}
 
 		static constexpr daw::UInt8 epsilon( ) noexcept {
@@ -3297,19 +3297,19 @@ namespace daw {
 
 	constexpr UInt32 operator"" _u32( unsigned long long value ) {
 		assert( ( value <= static_cast<unsigned long long>(
-		                     daw::numeric_limits<std::uint32_t>::max( ) ) ) );
+		                     (daw::numeric_limits<std::uint32_t>::max)( ) ) ) );
 		return static_cast<UInt32>( value );
 	}
 
 	constexpr UInt16 operator"" _u16( unsigned long long value ) {
 		assert( ( value < static_cast<unsigned long long>(
-		                    std::numeric_limits<std::uint16_t>::max( ) ) ) );
+		                    (std::numeric_limits<std::uint16_t>::max)( ) ) ) );
 		return static_cast<UInt16>( value );
 	}
 
 	constexpr UInt8 operator"" _u8( unsigned long long value ) {
 		assert( ( value < static_cast<unsigned long long>(
-		                    std::numeric_limits<std::uint8_t>::max( ) ) ) );
+		                    (std::numeric_limits<std::uint8_t>::max)( ) ) ) );
 		return static_cast<UInt8>( value );
 	}
 } // namespace daw

--- a/include/daw/daw_utility.h
+++ b/include/daw/daw_utility.h
@@ -8,10 +8,6 @@
 
 #pragma once
 
-#ifdef max
-#undef max
-#endif // max
-
 #include "cpp_17.h"
 #include "daw_algorithm.h"
 #include "daw_construct_a.h"
@@ -442,9 +438,9 @@ namespace daw {
 		static_assert( std::is_integral_v<IntegerSource>,
 		               "Must supply an integral type" );
 		if( value >= 0 ) {
-			return value <= std::numeric_limits<IntegerDest>::max( );
+			return value <= (std::numeric_limits<IntegerDest>::max)( );
 		} else if( std::numeric_limits<IntegerDest>::is_signed ) {
-			return value >= std::numeric_limits<IntegerDest>::min( );
+			return value >= (std::numeric_limits<IntegerDest>::min)( );
 		} else {
 			return false;
 		}
@@ -931,7 +927,7 @@ namespace daw {
 				if constexpr( sizeof( T ) <= sizeof( Integer ) ) {
 					return value;
 				} else if( value <=
-				           static_cast<T>( std::numeric_limits<Integer>::max( ) ) ) {
+				           static_cast<T>( (std::numeric_limits<Integer>::max)( ) ) ) {
 					return static_cast<Integer>( value );
 				} else {
 					daw::exception::daw_throw<std::out_of_range>( "value" );
@@ -943,7 +939,7 @@ namespace daw {
 				daw::exception::daw_throw<std::out_of_range>( "value" );
 			} else {
 				if( value >= 0 and
-				    value <= static_cast<T>( std::numeric_limits<Integer>::max( ) ) ) {
+				    value <= static_cast<T>( (std::numeric_limits<Integer>::max)( ) ) ) {
 					return value;
 				}
 				daw::exception::daw_throw<std::out_of_range>( "value" );
@@ -953,7 +949,7 @@ namespace daw {
 				return static_cast<Integer>( value );
 			} else {
 				daw::exception::precondition_check<std::out_of_range>(
-				  value <= static_cast<T>( std::numeric_limits<Integer>::max( ) ),
+				  value <= static_cast<T>( (std::numeric_limits<Integer>::max)( ) ),
 				  "value" );
 
 				return static_cast<Integer>( value );
@@ -961,7 +957,7 @@ namespace daw {
 		} else if constexpr( sizeof( T ) <= sizeof( Integer ) ) {
 			return static_cast<Integer>( value );
 		} else {
-			if( value <= static_cast<T>( std::numeric_limits<Integer>::max( ) ) ) {
+			if( value <= static_cast<T>( (std::numeric_limits<Integer>::max)( ) ) ) {
 				return static_cast<Integer>( value );
 			}
 			daw::exception::daw_throw<std::out_of_range>( "value" );

--- a/include/daw/daw_utility.h
+++ b/include/daw/daw_utility.h
@@ -438,9 +438,9 @@ namespace daw {
 		static_assert( std::is_integral_v<IntegerSource>,
 		               "Must supply an integral type" );
 		if( value >= 0 ) {
-			return value <= (std::numeric_limits<IntegerDest>::max)( );
+			return value <= ( std::numeric_limits<IntegerDest>::max )( );
 		} else if( std::numeric_limits<IntegerDest>::is_signed ) {
-			return value >= (std::numeric_limits<IntegerDest>::min)( );
+			return value >= ( std::numeric_limits<IntegerDest>::min )( );
 		} else {
 			return false;
 		}
@@ -926,8 +926,8 @@ namespace daw {
 			if constexpr( std::is_signed_v<Integer> ) {
 				if constexpr( sizeof( T ) <= sizeof( Integer ) ) {
 					return value;
-				} else if( value <=
-				           static_cast<T>( (std::numeric_limits<Integer>::max)( ) ) ) {
+				} else if( value <= static_cast<T>(
+				                      ( std::numeric_limits<Integer>::max )( ) ) ) {
 					return static_cast<Integer>( value );
 				} else {
 					daw::exception::daw_throw<std::out_of_range>( "value" );
@@ -939,7 +939,8 @@ namespace daw {
 				daw::exception::daw_throw<std::out_of_range>( "value" );
 			} else {
 				if( value >= 0 and
-				    value <= static_cast<T>( (std::numeric_limits<Integer>::max)( ) ) ) {
+				    value <=
+				      static_cast<T>( ( std::numeric_limits<Integer>::max )( ) ) ) {
 					return value;
 				}
 				daw::exception::daw_throw<std::out_of_range>( "value" );
@@ -949,7 +950,7 @@ namespace daw {
 				return static_cast<Integer>( value );
 			} else {
 				daw::exception::precondition_check<std::out_of_range>(
-				  value <= static_cast<T>( (std::numeric_limits<Integer>::max)( ) ),
+				  value <= static_cast<T>( ( std::numeric_limits<Integer>::max )( ) ),
 				  "value" );
 
 				return static_cast<Integer>( value );
@@ -957,7 +958,8 @@ namespace daw {
 		} else if constexpr( sizeof( T ) <= sizeof( Integer ) ) {
 			return static_cast<Integer>( value );
 		} else {
-			if( value <= static_cast<T>( (std::numeric_limits<Integer>::max)( ) ) ) {
+			if( value <=
+			    static_cast<T>( ( std::numeric_limits<Integer>::max )( ) ) ) {
 				return static_cast<Integer>( value );
 			}
 			daw::exception::daw_throw<std::out_of_range>( "value" );

--- a/include/daw/impl/daw_int_to_iterator.h
+++ b/include/daw/impl/daw_int_to_iterator.h
@@ -187,7 +187,7 @@ namespace daw {
 		                                       daw::tag_t<int> ) {
 
 			if( value < 0 ) {
-				if( value == (std::numeric_limits<Integer>::min)( ) ) {
+				if( value == ( std::numeric_limits<Integer>::min )( ) ) {
 					constexpr auto m = min_strings::get(
 					  CharT{ }, std::integral_constant<size_t, sizeof( Integer )>{ } );
 					return daw::algorithm::copy( m.begin( ), m.end( ), it );

--- a/include/daw/impl/daw_int_to_iterator.h
+++ b/include/daw/impl/daw_int_to_iterator.h
@@ -187,7 +187,7 @@ namespace daw {
 		                                       daw::tag_t<int> ) {
 
 			if( value < 0 ) {
-				if( value == std::numeric_limits<Integer>::min( ) ) {
+				if( value == (std::numeric_limits<Integer>::min)( ) ) {
 					constexpr auto m = min_strings::get(
 					  CharT{ }, std::integral_constant<size_t, sizeof( Integer )>{ } );
 					return daw::algorithm::copy( m.begin( ), m.end( ), it );

--- a/include/daw/impl/daw_math_impl.h
+++ b/include/daw/impl/daw_math_impl.h
@@ -25,7 +25,7 @@ namespace daw {
 	}
 
 	template<typename T, typename... Ts>
-	constexpr auto (max)( T const &val1, Ts const &...vs ) noexcept {
+	constexpr auto( max )( T const &val1, Ts const &...vs ) noexcept {
 		if constexpr( sizeof...( Ts ) > 1 ) {
 			auto const tmp = (max)( vs... );
 			using result_t = std::common_type_t<T, decltype( tmp )>;
@@ -65,7 +65,7 @@ namespace daw {
 	}
 
 	template<typename T, typename... Ts>
-	constexpr auto (min)( T const &val1, Ts const &...vs ) noexcept {
+	constexpr auto( min )( T const &val1, Ts const &...vs ) noexcept {
 		if constexpr( sizeof...( Ts ) > 1 ) {
 			auto const tmp = (min)( vs... );
 			using result_t = std::common_type_t<T, decltype( tmp )>;

--- a/include/daw/impl/daw_math_impl.h
+++ b/include/daw/impl/daw_math_impl.h
@@ -14,13 +14,6 @@
 #include <type_traits>
 #include <utility>
 
-#ifdef max
-#undef max
-#endif // max
-#ifdef min
-#undef min
-#endif // min
-
 namespace daw {
 	template<typename Float, std::enable_if_t<std::is_floating_point_v<Float>,
 	                                          std::nullptr_t> = nullptr>
@@ -32,9 +25,9 @@ namespace daw {
 	}
 
 	template<typename T, typename... Ts>
-	constexpr auto max( T const &val1, Ts const &...vs ) noexcept {
+	constexpr auto (max)( T const &val1, Ts const &...vs ) noexcept {
 		if constexpr( sizeof...( Ts ) > 1 ) {
-			auto const tmp = max( vs... );
+			auto const tmp = (max)( vs... );
 			using result_t = std::common_type_t<T, decltype( tmp )>;
 
 			if( std::less<>{ }( tmp, val1 ) ) {
@@ -72,9 +65,9 @@ namespace daw {
 	}
 
 	template<typename T, typename... Ts>
-	constexpr auto min( T const &val1, Ts const &...vs ) noexcept {
+	constexpr auto (min)( T const &val1, Ts const &...vs ) noexcept {
 		if constexpr( sizeof...( Ts ) > 1 ) {
-			auto const tmp = min( vs... );
+			auto const tmp = (min)( vs... );
 			using result_t = std::common_type_t<T, decltype( tmp )>;
 
 			if( not std::less<>{ }( tmp, val1 ) ) {

--- a/include/daw/iterator/daw_find_iterator.h
+++ b/include/daw/iterator/daw_find_iterator.h
@@ -24,7 +24,7 @@ namespace daw {
 		value_type current_value;
 
 		constexpr find_iterator( ) noexcept
-		  : current_value{ std::numeric_limits<value_type>::max( ) } {}
+		  : current_value{ (std::numeric_limits<value_type>::max)( ) } {}
 		constexpr find_iterator( value_type start_value ) noexcept
 		  : current_value{ start_value } {}
 		constexpr find_iterator( value_type start_value,

--- a/include/daw/iterator/daw_find_iterator.h
+++ b/include/daw/iterator/daw_find_iterator.h
@@ -24,7 +24,7 @@ namespace daw {
 		value_type current_value;
 
 		constexpr find_iterator( ) noexcept
-		  : current_value{ (std::numeric_limits<value_type>::max)( ) } {}
+		  : current_value{ ( std::numeric_limits<value_type>::max )( ) } {}
 		constexpr find_iterator( value_type start_value ) noexcept
 		  : current_value{ start_value } {}
 		constexpr find_iterator( value_type start_value,

--- a/include/daw/static_hash_table.h
+++ b/include/daw/static_hash_table.h
@@ -50,14 +50,14 @@ namespace daw {
 		template<typename K>
 		[[nodiscard]] static constexpr size_t hash_fn( K const &key ) {
 			return ( daw::fnv1a_hash( key ) %
-			         ( (std::numeric_limits<std::size_t>::max)( ) -
+			         ( ( std::numeric_limits<std::size_t>::max )( ) -
 			           static_cast<size_t>( hash_sentinals::Size ) ) ) +
 			       static_cast<size_t>( hash_sentinals::Size );
 		}
 
 		[[nodiscard]] static constexpr size_t hash_fn( char const *const key ) {
 			return ( daw::fnv1a_hash( key ) %
-			         ( (std::numeric_limits<std::size_t>::max)( ) -
+			         ( ( std::numeric_limits<std::size_t>::max )( ) -
 			           static_cast<size_t>( hash_sentinals::Size ) ) ) +
 			       static_cast<size_t>( hash_sentinals::Size );
 		}

--- a/include/daw/static_hash_table.h
+++ b/include/daw/static_hash_table.h
@@ -50,14 +50,14 @@ namespace daw {
 		template<typename K>
 		[[nodiscard]] static constexpr size_t hash_fn( K const &key ) {
 			return ( daw::fnv1a_hash( key ) %
-			         ( std::numeric_limits<size_t>::max( ) -
+			         ( (std::numeric_limits<std::size_t>::max)( ) -
 			           static_cast<size_t>( hash_sentinals::Size ) ) ) +
 			       static_cast<size_t>( hash_sentinals::Size );
 		}
 
 		[[nodiscard]] static constexpr size_t hash_fn( char const *const key ) {
 			return ( daw::fnv1a_hash( key ) %
-			         ( std::numeric_limits<size_t>::max( ) -
+			         ( (std::numeric_limits<std::size_t>::max)( ) -
 			           static_cast<size_t>( hash_sentinals::Size ) ) ) +
 			       static_cast<size_t>( hash_sentinals::Size );
 		}


### PR DESCRIPTION
To help in cases where /permissive- or like are not setup in MSVC, put brackets around min/max function/member function calls and definitions