### PR TITLE
Added direct support for __builtin_unreachable on clang/gcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project("daw-header-libraries"
-        VERSION "1.25.3"
+        VERSION "1.26.0"
         DESCRIPTION "Various headers"
         HOMEPAGE_URL "https://github.com/beached/header_libraries"
         LANGUAGES C CXX)

--- a/include/daw/daw_unreachable.h
+++ b/include/daw/daw_unreachable.h
@@ -16,6 +16,9 @@
 #define DAW_UNREACHABLE( ) __builtin_unreachable( )
 #elif defined( _MSC_VER )
 #define DAW_UNREACHABLE( ) __assume( false );
+#elif defined( __GNUC__ ) or defined( __clang__ )
+// All gcc/clang compilers supporting c++17 have __builtin_unreachable
+#define DAW_UNREACHABLE( ) __builtin_unreachable( )
 #else
 #include <exception>
 #define DAW_UNREACHABLE( ) std::terminate( )


### PR DESCRIPTION
Added direct support for __builtin_unreachable on clang/gcc.  All
versions supporting C++17 and far back have it