### PR TITLE
DAW_ATTRIB_INLINE now says inline for gcc/clang too

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project("daw-header-libraries"
-    VERSION "1.38.3"
+    VERSION "1.39.0"
     DESCRIPTION "Various headers"
     HOMEPAGE_URL "https://github.com/beached/header_libraries"
     LANGUAGES C CXX

--- a/include/daw/daw_attributes.h
+++ b/include/daw/daw_attributes.h
@@ -33,7 +33,7 @@
 
 #define DAW_ATTRIB_HIDDEN __attribute__ ((visibility ("hidden")))
 
-#define DAW_ATTRIB_INLINE [[gnu::always_inline]]
+#define DAW_ATTRIB_INLINE [[gnu::always_inline]] inline
 #define DAW_ATTRIB_NOINLINE [[gnu::noinline]]
 
 #elif defined( _MSC_VER )

--- a/include/daw/daw_cxmath.h
+++ b/include/daw/daw_cxmath.h
@@ -552,7 +552,7 @@ namespace daw::cxmath {
 #endif
 
 	namespace cxmath_impl {
-		[[nodiscard]] DAW_ATTRIB_INLINE inline constexpr std::uint32_t
+		[[nodiscard]] DAW_ATTRIB_INLINE constexpr std::uint32_t
 		count_trailing_zeros_cx32( std::uint32_t v ) noexcept {
 			if( v == 0 ) {
 				return 32U;
@@ -580,7 +580,7 @@ namespace daw::cxmath {
 			return c;
 		}
 
-		[[nodiscard]] DAW_ATTRIB_INLINE inline constexpr std::uint32_t
+		[[nodiscard]] DAW_ATTRIB_INLINE constexpr std::uint32_t
 		count_trailing_zeros_cx64( std::uint64_t v ) noexcept {
 			if( v == 0 ) {
 				return 64U;
@@ -593,7 +593,7 @@ namespace daw::cxmath {
 		}
 
 		template<typename T>
-		[[nodiscard]] DAW_ATTRIB_INLINE inline constexpr std::uint32_t
+		[[nodiscard]] DAW_ATTRIB_INLINE constexpr std::uint32_t
 		count_trailing_zeros_cx( T v ) noexcept {
 			static_assert( sizeof( T ) == 8 or sizeof( T ) == 4 );
 			if constexpr( sizeof( T ) == 8 ) {


### PR DESCRIPTION
This makes it easier to deal with MSVC's __forceinline meaning ODR inline too