### PR TITLE
Added do_resize_and_overwrite tagged ctors, block_create_from, block_append_from

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project("daw-header-libraries"
-        VERSION "2.27.0"
+        VERSION "2.28.0"
         DESCRIPTION "Various headers"
         HOMEPAGE_URL "https://github.com/beached/header_libraries"
         LANGUAGES C CXX

--- a/tests/vector_test.cpp
+++ b/tests/vector_test.cpp
@@ -6,10 +6,23 @@
 // Official repository: https://github.com/beached/
 //
 
+#include <daw/daw_algorithm.h>
+#include <daw/daw_consteval.h>
 #include <daw/vector.h>
 
 #include <cstddef>
 #include <iostream>
+
+DAW_CONSTEVAL int sum( std::size_t n ) {
+	auto v = daw::vector<int>(
+	  daw::do_resize_and_overwrite, n, []( int *ptr, std::size_t n ) {
+		  for( std::size_t idx = 0; idx < n; ++idx ) {
+			  std::construct_at( &ptr[idx], static_cast<int>( idx ) );
+		  }
+		  return n;
+	  } );
+	return daw::algorithm::accumulate( v.begin( ), v.end( ), 0 );
+}
 
 int main( ) {
 	daw::vector<int> x;
@@ -19,11 +32,13 @@ int main( ) {
 	std::cout << "cap: " << x.capacity( ) << '\n';
 	x.resize_and_overwrite( x.capacity( ) * 2, []( int *p, std::size_t sz ) {
 		for( std::size_t n = 0; n < sz; ++n ) {
-			p[n] = n;
+			std::construct_at( &p[n], n );
 		}
 		return sz;
 	} );
 	for( auto const &i : x ) {
 		std::cout << i << '\n';
 	}
+	constexpr int a = sum( 10 );
+	static_assert( a == 45 );
 }


### PR DESCRIPTION
Added do_resize_and_overwrite tagged ctors, block_create_from, block_append_from

* block_create_from constructs a new vector and fills it from an input
iterator block_size at a time
* block_append_from appends to an existing iterator up to block_size items
at a time