### PR TITLE
Doing alternate token defines without another include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required( VERSION 3.14 )
 
 project( "daw-header-libraries"
-         VERSION "2.91.2"
+         VERSION "2.91.4"
          DESCRIPTION "Various headers"
          HOMEPAGE_URL "https://github.com/beached/header_libraries"
          LANGUAGES C CXX

--- a/include/daw/ciso646.h
+++ b/include/daw/ciso646.h
@@ -13,6 +13,16 @@
 
 #if defined( _MSC_EXTENSIONS ) || defined( DAW_FORCE_CISO646 ) or defined( _MSC_VER )
 #if defined( _MSC_EXTENSIONS ) || defined( DAW_FORCE_CISO646 ) || _MSC_VER < 1930 || _MSVC_LANG < 202002L
-#include <ciso646>
+#define and    &&
+#define and_eq &=
+#define bitand &
+#define bitor  |
+#define compl  ~
+#define not    !
+#define not_eq !=
+#define or     ||
+#define or_eq  |=
+#define xor    ^
+#define xor_eq ^=
 #endif
 #endif


### PR DESCRIPTION
Doing alternate token defines without another include.  This allows for homogeneity with clang-cl/msvc 