### PR TITLE
Fixed bug introduced with search improvement.  clang-8 does not have a

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required( VERSION 3.14 )
 
 project( "daw-header-libraries"
-         VERSION "2.91.4"
+         VERSION "2.92.0"
          DESCRIPTION "Various headers"
          HOMEPAGE_URL "https://github.com/beached/header_libraries"
          LANGUAGES C CXX

--- a/include/daw/daw_is_constant_evaluated.h
+++ b/include/daw/daw_is_constant_evaluated.h
@@ -34,3 +34,9 @@
 #define DAW_IS_CONSTANT_EVALUATED( ) __builtin_is_constant_evaluated( )
 
 #endif
+
+#if defined( DAW_IS_CONSTANT_EVALUATED )
+#define DAW_IS_CONSTANT_EVALUATED_COMPAT( ) DAW_IS_CONSTANT_EVALUATED()
+#else
+#define DAW_IS_CONSTANT_EVALUATED_COMPAT( ) true
+#endif

--- a/include/daw/daw_string_view2.h
+++ b/include/daw/daw_string_view2.h
@@ -249,7 +249,7 @@ namespace daw {
 			        ForwardIt2 s_last ) {
 				// TODO: This is a terrible detection, but not sure what to use yet as
 				// it's generally available everywhere but windows
-#if not defined( _WIN32 )
+#if not defined( _WIN32 ) and defined( DAW_IS_CONSTANT_EVALUATED )
 				if constexpr( std::is_convertible_v<ForwardIt1, char const *> and
 				              std::is_convertible_v<ForwardIt2, char const *> ) {
 					if( not DAW_IS_CONSTANT_EVALUATED( ) ) {


### PR DESCRIPTION
Fixed bug introduced with search improvement.  clang-8 does not have a way to do IS_CONSTANt_EVALUATED