### PR TITLE
Fix typo in macro definition for unreachable feature check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required( VERSION 3.14 )
 
 project( "daw-header-libraries"
-         VERSION "2.115.0"
+         VERSION "2.115.1"
          DESCRIPTION "Various headers"
          HOMEPAGE_URL "https://github.com/beached/header_libraries"
          LANGUAGES C CXX

--- a/include/daw/daw_cpp_feature_check.h
+++ b/include/daw/daw_cpp_feature_check.h
@@ -174,6 +174,6 @@ inline constexpr bool daw_has_cx_cmath = false;
 
 #if defined( __cpp_lib_unreachable )
 #if __cpp_lib_unreachable >= 202202L
-#defined DAW_HAS_CPP23_UNREACHABLE
+#define DAW_HAS_CPP23_UNREACHABLE
 #endif
 #endif


### PR DESCRIPTION
Corrected a typo from `#defined` to `#define` in feature check for `__cpp_lib_unreachable`. This ensures proper detection of the C++23 `unreachable` feature.