### PR TITLE
Remove unreachable code from daw_visit.h

### DIFF
--- a/include/daw/daw_visit.h
+++ b/include/daw/daw_visit.h
@@ -356,7 +356,6 @@ namespace daw {
 			} else {
 				return DAW_FWD( vis )( get_nt<0 + N>( DAW_FWD( var ) ) );
 			}
-			DAW_UNREACHABLE( );
 		}
 
 #undef DAW_VISIT_CASE


### PR DESCRIPTION
The DAW_UNREACHABLE macro call was removed as it was redundant and unreachable in the given context.