### PR TITLE
Add atomic wait utilities and corresponding tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required( VERSION 3.14 )
 
 project( "daw-header-libraries"
-         VERSION "2.117.0"
+         VERSION "2.118.0"
          DESCRIPTION "Various headers"
          HOMEPAGE_URL "https://github.com/beached/header_libraries"
          LANGUAGES C CXX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required( VERSION 3.14 )
 
 project( "daw-header-libraries"
-         VERSION "2.116.0"
+         VERSION "2.117.0"
          DESCRIPTION "Various headers"
          HOMEPAGE_URL "https://github.com/beached/header_libraries"
          LANGUAGES C CXX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required( VERSION 3.14 )
 
 project( "daw-header-libraries"
-         VERSION "2.115.1"
+         VERSION "2.116.0"
          DESCRIPTION "Various headers"
          HOMEPAGE_URL "https://github.com/beached/header_libraries"
          LANGUAGES C CXX

--- a/include/daw/daw_atomic_wait.h
+++ b/include/daw/daw_atomic_wait.h
@@ -286,9 +286,9 @@ namespace daw {
 	 * @param order The memory order to use. Defaults to
 	 * `std::memory_order_acquire`.
 	 */
-	void
-	atomic_wait_value( std::atomic<T> const *object, T const &desired_value,
-	                   std::memory_order order = std::memory_order_acquire ) {
+	void atomic_wait_value_equal(
+	  std::atomic<T> const *object, T const &desired_value,
+	  std::memory_order order = std::memory_order_acquire ) {
 		atomic_wait_if(
 		  object,
 		  [&desired_value]( T const &current_value ) {
@@ -320,10 +320,10 @@ namespace daw {
 	 * or a timeout occurred.
 	 */
 	template<typename T, typename Rep, typename Period>
-	[[nodiscard]] wait_status
-	atomic_wait_value_for( std::atomic<T> const *object, T const &desired_value,
-	                       std::chrono::duration<Rep, Period> const &rel_time,
-	                       std::memory_order order = std::memory_order_acquire ) {
+	[[nodiscard]] wait_status atomic_wait_value_equal_for(
+	  std::atomic<T> const *object, T const &desired_value,
+	  std::chrono::duration<Rep, Period> const &rel_time,
+	  std::memory_order order = std::memory_order_acquire ) {
 		return atomic_wait_if_for(
 		  object,
 		  [&desired_value]( T const &current_value ) {
@@ -355,7 +355,7 @@ namespace daw {
 	 * or a timeout occurred.
 	 */
 	template<typename T, typename Clock, typename Duration>
-	[[nodiscard]] wait_status atomic_wait_value_until(
+	[[nodiscard]] wait_status atomic_wait_value_equal_until(
 	  std::atomic<T> const *object, T const &desired_value,
 	  std::chrono::time_point<Clock, Duration> const &timeout_time,
 	  std::memory_order order = std::memory_order_acquire ) {

--- a/include/daw/daw_atomic_wait.h
+++ b/include/daw/daw_atomic_wait.h
@@ -1,0 +1,370 @@
+// Copyright (c) Darrell Wright
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/beached/header_libraries
+//
+
+#pragma once
+
+#include "daw_attributes.h"
+#include "daw_concepts.h"
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <utility>
+
+namespace daw {
+	enum class wait_status { found, timeout };
+}
+
+namespace daw::atomic_impl {
+	inline constexpr struct {
+		DAW_ATTRIB_INLINE DAW_CPP23_STATIC_CALL_OP bool operator( )(
+		  std::chrono::nanoseconds elapsed ) DAW_CPP23_STATIC_CALL_OP_CONST {
+			if( elapsed > std::chrono::milliseconds( 128 ) ) {
+				std::this_thread::sleep_for( std::chrono::milliseconds( 8 ) );
+			} else if( elapsed > std::chrono::microseconds( 64 ) ) {
+				std::this_thread::sleep_for( elapsed / 2 );
+			} else if( elapsed > std::chrono::microseconds( 4 ) ) {
+				std::this_thread::yield( );
+			} else {
+				// poll
+			}
+			return false;
+		}
+	} timed_backoff_policy{ };
+
+	[[nodiscard]] bool
+	poll_with_backoff( Fn<bool( std::chrono::nanoseconds )> auto &&backoff_policy,
+	                   Fn<bool( )> auto &&func,
+	                   std::chrono::nanoseconds max_elapsed ) {
+
+		auto const start_time = std::chrono::high_resolution_clock::now( );
+		int count = 0;
+		while( true ) {
+			if( func( ) ) {
+				return true;
+			}
+			if( count < 64 ) {
+				++count;
+				continue;
+			}
+			auto const elapsed =
+			  std::chrono::high_resolution_clock::now( ) - start_time;
+			if( elapsed >= max_elapsed ) {
+				return false;
+			}
+			if( backoff_policy( elapsed ) ) {
+				return false;
+			}
+		}
+	}
+} // namespace daw::atomic_impl
+
+namespace daw {
+
+	template<typename T, typename Rep, typename Period>
+	/**
+	 * Waits for the atomic object to change from the old value or until the
+	 * timeout expires.
+	 *
+	 * This function blocks the calling thread, periodically polling the atomic
+	 * object, and returns as soon as the atomic value differs from the specified
+	 * old value or the relative timeout period elapses.
+	 *
+	 * @tparam T The type of the atomic object.
+	 * @tparam Rep The representation type of the relative time duration.
+	 * @tparam Period The tick period type of the relative time duration.
+	 *
+	 * @param object Pointer to the atomic object to wait on.
+	 * @param old The value that the atomic object is expected to differ from.
+	 * @param rel_time The maximum duration to wait before timing out.
+	 * @param order The memory order to use for atomic load operations. Defaults
+	 * to `std::memory_order_acquire`.
+	 *
+	 * @return A wait_status indicating whether the atomic value changed or the
+	 * timeout expired.
+	 */
+	[[nodiscard]] wait_status
+	atomic_wait_for( std::atomic<T> const *object, T const &old,
+	                 std::chrono::duration<Rep, Period> const &rel_time,
+	                 std::memory_order order = std::memory_order_acquire ) {
+		auto const final_time =
+		  std::chrono::high_resolution_clock::now( ) + rel_time;
+		auto current =
+		  std::atomic_load_explicit( object, std::memory_order_acquire );
+
+		for( int tries = 0; current == old and tries < 16; ++tries ) {
+			std::this_thread::yield( );
+			current = std::atomic_load_explicit( object, order );
+		}
+		auto const poll_fn = [&] {
+			current = std::atomic_load_explicit( object, order );
+			if( current != old ) {
+				return true;
+			}
+			auto const current_time = std::chrono::high_resolution_clock::now( );
+			auto const is_timed_out = current_time >= final_time;
+			return is_timed_out;
+		};
+		(void)atomic_impl::poll_with_backoff( atomic_impl::timed_backoff_policy,
+		                                      poll_fn, rel_time );
+		if( current == old ) {
+			return wait_status::timeout;
+		}
+		return wait_status::found;
+	}
+
+	/**
+	 * Waits until the atomic object changes from the specified value or the
+	 * timeout time is reached.
+	 *
+	 * This function blocks the calling thread until the atomic value
+	 * pointed to by `object` is not equal to `old` or until the specified
+	 * `timeout_time` is reached.
+	 *
+	 * @tparam T The type of the atomic object.
+	 * @tparam Clock The clock type used to measure the timeout.
+	 * @tparam Duration The duration type used to represent the timeout.
+	 *
+	 * @param object Pointer to the atomic object to wait on.
+	 * @param old The value that the atomic object is expected to change from
+	 * @param timeout_time The time point at which the wait is aborted if the
+	 * value has not been reached.
+	 * @param order The memory order to use. Defaults to
+	 * `std::memory_order_acquire`.
+	 *
+	 * @return A `wait_status` indicating whether the wait was successful or if it
+	 * timed out.
+	 */
+	template<typename T, typename Clock, typename Duration>
+	[[nodiscard]] wait_status atomic_wait_until(
+	  std::atomic<T> const *object, T const &old,
+	  std::chrono::time_point<Clock, Duration> const &timeout_time,
+	  std::memory_order order = std::memory_order_acquire ) {
+
+		return daw::atomic_wait_for( object, std::move( old ),
+		                             timeout_time - Clock::now( ), order );
+	}
+
+	/**
+	 * Waits until the atomic object satisfies the given predicate.
+	 *
+	 * This function blocks the calling thread until the value of the atomic
+	 * object pointed to by `object` satisfies the provided `predicate`.
+	 *
+	 * @tparam T The type of the atomic object.
+	 * @tparam Fn A templated function type that takes a value of type T and
+	 * returns bool.
+	 *
+	 * @param object Pointer to the atomic object to wait on.
+	 * @param predicate A callable object (such as a lambda or function object)
+	 * that takes a value of type T and returns a boolean indicating whether the
+	 * condition is met.
+	 * @param order The memory order to use. Defaults to
+	 * `std::memory_order_acquire`.
+	 */
+	template<typename T>
+	void atomic_wait_if( std::atomic<T> const *object,
+	                     Fn<bool( T )> auto &&predicate,
+	                     std::memory_order order = std::memory_order_acquire ) {
+		auto current =
+		  std::atomic_load_explicit( object, std::memory_order_acquire );
+		auto const &const_current = current;
+		while( not predicate( const_current ) ) {
+			std::atomic_wait_explicit( object, current, order );
+			current = std::atomic_load_explicit( object, std::memory_order_relaxed );
+		}
+	}
+
+	/**
+	 * Waits for an atomic object to satisfy a predicate within a specified time
+	 * duration.
+	 *
+	 * This function blocks the calling thread until the predicate applied
+	 * to the atomic object evaluates to true or the specified timeout period
+	 * elapses.
+	 *
+	 * @tparam T The type of the atomic object.
+	 * @tparam Fn A callable type that returns a boolean value when applied to an
+	 * object of type T.
+	 * @tparam Rep A type representing the number of ticks of the time duration.
+	 * @tparam Period A std::ratio type representing the tick period of the time
+	 * duration.
+	 *
+	 * @param object Pointer to the atomic object to wait on.
+	 * @param predicate Predicate function to apply to the atomic object's value.
+	 * @param rel_time The relative time duration to wait for the predicate to
+	 * become true.
+	 * @param order The memory order to use for atomic operations. Defaults to
+	 * `std::memory_order_acquire`.
+	 *
+	 * @return Returns wait_status::found if the predicate evaluates to true
+	 * before the timeout, and wait_status::timeout otherwise.
+	 */
+	template<typename T, typename Rep, typename Period>
+	[[nodiscard]] wait_status
+	atomic_wait_if_for( std::atomic<T> const *object,
+	                    Fn<bool( T )> auto &&predicate,
+	                    std::chrono::duration<Rep, Period> const &rel_time,
+	                    std::memory_order order = std::memory_order_acquire ) {
+		auto const final_time =
+		  std::chrono::high_resolution_clock::now( ) + rel_time;
+		auto current_value =
+		  std::atomic_load_explicit( object, std::memory_order_acquire );
+
+		for( int tries = 0; not predicate( current_value ) and tries < 16;
+		     ++tries ) {
+			std::this_thread::yield( );
+			current_value = std::atomic_load_explicit( object, order );
+		}
+		auto const poll_fn = [&] {
+			current_value = std::atomic_load_explicit( object, order );
+			auto const pred_result = predicate( current_value );
+			if( pred_result ) {
+				return true;
+			}
+			auto const current_time = std::chrono::high_resolution_clock::now( );
+			auto const is_timed_out = current_time >= final_time;
+			return is_timed_out;
+		};
+		(void)atomic_impl::poll_with_backoff( atomic_impl::timed_backoff_policy,
+		                                      poll_fn, rel_time );
+		if( predicate( current_value ) ) {
+			return wait_status::found;
+		}
+		return wait_status::timeout;
+	}
+
+	/**
+	 * Waits until the atomic object satisfies the given predicate or the absolute
+	 * timeout time is reached.
+	 *
+	 * This function blocks the calling thread until the atomic value pointed to
+	 * by `object` satisfies the `predicate` function or the specified timeout
+	 * time `timeout_time` is reached.
+	 *
+	 * @tparam T The type of the atomic object.
+	 * @tparam Clock The clock used for the timeout.
+	 * @tparam Duration The duration type used by the clock.
+	 * @tparam Fn A callable type that takes a value of type T and returns a bool.
+	 *
+	 * @param object Pointer to the atomic object to wait on.
+	 * @param predicate A callable that takes the atomic object's value and
+	 * returns whether it satisfies the condition.
+	 * @param timeout_time The absolute time point by which the wait operation
+	 * should be aborted if the predicate is not satisfied.
+	 * @param order The memory order to use. Defaults to
+	 * std::memory_order_acquire.
+	 *
+	 * @return A `wait_status` enum indicating whether the predicate was satisfied
+	 * or a timeout occurred.
+	 */
+	template<typename T, typename Clock, typename Duration>
+	[[nodiscard]] wait_status atomic_wait_if_until(
+	  std::atomic<T> const *object, Fn<bool( T )> auto &&predicate,
+	  std::chrono::time_point<Clock, Duration> const &timeout_time,
+	  std::memory_order order = std::memory_order_acquire ) {
+		return daw::atomic_wait_if_for( object, std::move( predicate ),
+		                                timeout_time - Clock::now( ), order );
+	}
+
+	template<typename T>
+	/**
+	 * Waits until the atomic object reaches the desired value.
+	 *
+	 * This function blocks the calling thread until the atomic value
+	 * pointed to by `object` equals `desired_value`.
+	 *
+	 * @tparam T The type of the atomic object.
+	 *
+	 * @param object Pointer to the atomic object to wait on.
+	 * @param desired_value The value that the atomic object is expected to reach.
+	 * @param order The memory order to use. Defaults to
+	 * `std::memory_order_acquire`.
+	 */
+	void
+	atomic_wait_value( std::atomic<T> const *object, T const &desired_value,
+	                   std::memory_order order = std::memory_order_acquire ) {
+		atomic_wait_if(
+		  object,
+		  [&desired_value]( T const &current_value ) {
+			  return current_value == desired_value;
+		  },
+		  order );
+	}
+
+	/**
+	 * Waits until the atomic object reaches the desired value or the relative
+	 * time duration has elapsed.
+	 *
+	 * This function blocks the calling thread until the atomic value pointed to
+	 * by `object` equals `desired_value` or the specified relative time duration
+	 * `rel_time` has elapsed.
+	 *
+	 * @tparam T The type of the atomic object.
+	 * @tparam Rep The type representing the number of ticks.
+	 * @tparam Period The type representing the tick period.
+	 *
+	 * @param object Pointer to the atomic object to wait on.
+	 * @param desired_value The value that the atomic object is expected to reach.
+	 * @param rel_time The maximum duration to wait for the atomic object to reach
+	 * the desired value.
+	 * @param order The memory order to use. Defaults to
+	 * `std::memory_order_acquire`.
+	 *
+	 * @return A `wait_status` enum indicating whether the desired value was found
+	 * or a timeout occurred.
+	 */
+	template<typename T, typename Rep, typename Period>
+	[[nodiscard]] wait_status
+	atomic_wait_value_for( std::atomic<T> const *object, T const &desired_value,
+	                       std::chrono::duration<Rep, Period> const &rel_time,
+	                       std::memory_order order = std::memory_order_acquire ) {
+		return atomic_wait_if_for(
+		  object,
+		  [&desired_value]( T const &current_value ) {
+			  return current_value == desired_value;
+		  },
+		  rel_time, order );
+	}
+
+	/**
+	 * Waits until the specified object reaches the desired value or the timeout
+	 * is reached.
+	 *
+	 * This function blocks the calling thread until the atomic value pointed to
+	 * by `object` equals `desired_value` or the specified timeout time
+	 * `timeout_time` is reached.
+	 *
+	 * @tparam T The type of the atomic object.
+	 * @tparam Clock The clock used for the timeout.
+	 * @tparam Duration The duration type used by the clock.
+	 *
+	 * @param object Pointer to the atomic object to wait on.
+	 * @param desired_value The value that the atomic object is expected to reach.
+	 * @param timeout_time The absolute time point by which the wait operation
+	 * should be aborted if the desired value is not reached.
+	 * @param order The memory order to use. Defaults to
+	 * `std::memory_order_acquire`.
+	 *
+	 * @return A `wait_status` enum indicating whether the desired value was found
+	 * or a timeout occurred.
+	 */
+	template<typename T, typename Clock, typename Duration>
+	[[nodiscard]] wait_status atomic_wait_value_until(
+	  std::atomic<T> const *object, T const &desired_value,
+	  std::chrono::time_point<Clock, Duration> const &timeout_time,
+	  std::memory_order order = std::memory_order_acquire ) {
+		return daw::atomic_wait_if_for(
+		  object,
+		  [&desired_value]( T const &current_value ) {
+			  return current_value == desired_value;
+		  },
+		  timeout_time - Clock::now( ), order );
+	}
+
+} // namespace daw

--- a/include/daw/daw_attributes.h
+++ b/include/daw/daw_attributes.h
@@ -123,9 +123,9 @@
 #endif
 
 #if defined( DAW_HAS_GCC_LIKE )
-#define DAW_ATTRIB_NONNULL _Nonnull
+#define DAW_ATTRIB_NONNULL(...) [[gnu::nonnull __VA_ARGS__]]
 #define DAW_ATTRIB_RET_NONNULL [[gnu::returns_nonnull]]
 #else
-#define DAW_ATTRIB_NONNULL
+#define DAW_ATTRIB_NONNULL(...)
 #define DAW_ATTRIB_RET_NONNULL
 #endif

--- a/include/daw/daw_attributes.h
+++ b/include/daw/daw_attributes.h
@@ -123,7 +123,9 @@
 #endif
 
 #if defined( DAW_HAS_GCC_LIKE )
-#define DAW_ATTRIB_NONNULL _NonNull 
+#define DAW_ATTRIB_NONNULL _Nonnull
+#define DAW_ATTRIB_RET_NONNULL [[gnu::returns_nonnull]]
 #else
 #define DAW_ATTRIB_NONNULL
+#define DAW_ATTRIB_RET_NONNULL
 #endif

--- a/include/daw/daw_attributes.h
+++ b/include/daw/daw_attributes.h
@@ -121,3 +121,9 @@
 #else
 #define DAW_ATTRIB_RETNOTNULL
 #endif
+
+#if defined( DAW_HAS_GCC_LIKE )
+#define DAW_ATTRIB_NONNULL _NonNull 
+#else
+#define DAW_ATTRIB_NONNULL
+#endif

--- a/include/daw/daw_concepts.h
+++ b/include/daw/daw_concepts.h
@@ -413,4 +413,16 @@ namespace daw {
 
 	template<typename From, typename To>
 	concept constructible_to = constructible_from<To, From>;
+
+	namespace concepts_details {
+		template<typename, typename>
+		inline constexpr bool Fn_v = false;
+
+		template<typename F, typename R, typename... Args>
+		inline constexpr bool Fn_v<F, R( Args... )> =
+		  std::is_invocable_r_v<R, F, Args...>;
+	} // namespace concepts_details
+
+	template<typename F, typename ExpectedF>
+	concept Fn = concepts_details::Fn_v<F, ExpectedF>;
 } // namespace daw

--- a/include/daw/pipelines/enumerate.h
+++ b/include/daw/pipelines/enumerate.h
@@ -17,7 +17,7 @@
 #include <limits>
 
 namespace daw::pipelines::pimpl {
-  template<typename EnumType = std::size_t>
+	template<typename EnumType = std::size_t>
 	struct Enumerate_t {
 		template<typename R>
 		[[nodiscard]] DAW_CPP23_STATIC_CALL_OP constexpr auto
@@ -29,7 +29,19 @@ namespace daw::pipelines::pimpl {
 		}
 	};
 
-  template<typename EnumType = std::size_t>
+	template<typename EnumType = std::size_t>
+	struct EnumerateFrom_t {
+		EnumType offset = EnumType{ };
+		template<typename R>
+		[[nodiscard]] constexpr auto operator( )( R &&r ) const {
+			static_assert( Range<R> );
+			return zip_view<iota_view<EnumType>, daw::remove_cvref_t<R>>(
+			  iota_view<EnumType>( offset, std::numeric_limits<EnumType>::max( ) ),
+			  DAW_FWD( r ) );
+		}
+	};
+
+	template<typename EnumType = std::size_t>
 	struct EnumerateApply_t {
 		template<typename R>
 		[[nodiscard]] DAW_CPP23_STATIC_CALL_OP constexpr auto
@@ -37,10 +49,28 @@ namespace daw::pipelines::pimpl {
 			if constexpr( RandomRange<R> ) {
 				auto const sz = static_cast<EnumType>(
 				  std::distance( std::begin( r ), std::end( r ) ) );
-				return ZipMore( iota_view<EnumType>( 0, sz ), DAW_FWD( r ) );
+				return ZipMore( iota_view<EnumType>( EnumType{ }, sz ), DAW_FWD( r ) );
+			} else {
+				return ZipMore( iota_view<EnumType>(
+				                  EnumType{ }, std::numeric_limits<EnumType>::max( ) ),
+				                DAW_FWD( r ) );
+			}
+		}
+	};
+
+	template<typename EnumType = std::size_t>
+	struct EnumerateApplyFrom_t {
+		EnumType offset = EnumType{ };
+		template<typename R>
+		[[nodiscard]] constexpr auto operator( )( R &&r ) const {
+			if constexpr( RandomRange<R> ) {
+				auto const sz = static_cast<EnumType>(
+				  std::distance( std::begin( r ), std::end( r ) ) );
+				return ZipMore( iota_view<EnumType>( offset, offset + sz ),
+				                DAW_FWD( r ) );
 			} else {
 				return ZipMore(
-				  iota_view<EnumType>( 0, std::numeric_limits<EnumType>::max( ) ),
+				  iota_view<EnumType>( offset, std::numeric_limits<EnumType>::max( ) ),
 				  DAW_FWD( r ) );
 			}
 		}
@@ -49,12 +79,23 @@ namespace daw::pipelines::pimpl {
 
 namespace daw::pipelines {
 	inline constexpr auto Enumerate = pimpl::Enumerate_t<>{ };
-  
-  template<typename EnumType>
+
+	template<typename EnumType>
 	inline constexpr auto EnumerateWith = pimpl::Enumerate_t<EnumType>{ };
-  
+
 	inline constexpr auto EnumerateApply = pimpl::EnumerateApply_t<>{ };
-  
-  template<typename EnumType>
-	inline constexpr auto EnumerateApplyWith = pimpl::EnumerateApply_t<EnumType>{ };
+
+	template<typename EnumType>
+	inline constexpr auto EnumerateApplyWith =
+	  pimpl::EnumerateApply_t<EnumType>{ };
+
+	template<typename EnumType = std::size_t>
+	constexpr auto EnumerateFrom( EnumType offset ) {
+		return pimpl::EnumerateFrom_t<EnumType>{ offset };
+	}
+
+	template<typename EnumType = std::size_t>
+	constexpr auto EnumerateApplyFrom( EnumType offset ) {
+		return pimpl::EnumerateApplyFrom_t<EnumType>{ offset };
+	}
 } // namespace daw::pipelines

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set( TEST_SOURCES
 		 daw_arith_traits_test.cpp
 		 daw_array_test.cpp
 		 daw_assume_test.cpp
+		 daw_attributes_test.cpp
 		 daw_benchmark_test.cpp
 		 daw_bounded_vector_test.cpp
 		 daw_constant_test.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -138,6 +138,7 @@ set( DEPRECATED_TEST_SOURCES
 		 )
 
 set( CPP20_TEST_SOURCES
+		 daw_atomic_wait_test.cpp
 		 daw_concepts_test.cpp
 		 daw_contiguous_view_test.cpp
 		 daw_formatters_test.cpp

--- a/tests/daw_atomic_wait_test.cpp
+++ b/tests/daw_atomic_wait_test.cpp
@@ -1,0 +1,216 @@
+// Copyright (c) Darrell Wright
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/beached/header_libraries
+//
+
+#include <daw/daw_atomic_wait.h>
+#include <daw/daw_attributes.h>
+#include <daw/daw_ensure.h>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+DAW_ATTRIB_NOINLINE void test_atomic_wait_value_until_timeout( ) {
+	auto value = std::atomic<int>{ };
+	auto result = daw::atomic_wait_value_until(
+	  &value, 42, std::chrono::system_clock::now( ) + 30ms );
+	daw_ensure( result == daw::wait_status::timeout );
+	daw_ensure( value == 0 );
+}
+
+DAW_ATTRIB_NOINLINE void test_atomic_wait_value_until_no_timeout( ) {
+	auto value = std::atomic<int>{ };
+
+	auto th = std::thread( [&value] {
+		std::this_thread::sleep_for( 500ms );
+		value = 42;
+		std::atomic_notify_one( &value );
+	} );
+	auto const result = daw::atomic_wait_value_until(
+	  &value, 42, std::chrono::system_clock::now( ) + 1min );
+	th.join( );
+	daw_ensure( result == daw::wait_status::found );
+	daw_ensure( value == 42 );
+}
+
+DAW_ATTRIB_NOINLINE void test_atomic_wait_value_for_timeout( ) {
+	auto value = std::atomic<int>{ };
+	auto result = daw::atomic_wait_value_for( &value, 42, 30ms );
+	daw_ensure( result == daw::wait_status::timeout );
+	daw_ensure( value == 0 );
+}
+
+DAW_ATTRIB_NOINLINE void test_atomic_wait_value_for_no_timeout( ) {
+	auto value = std::atomic<int>{ };
+
+	auto th = std::thread( [&value] {
+		std::this_thread::sleep_for( 500ms );
+		value = 42;
+		std::atomic_notify_one( &value );
+	} );
+	auto const result = daw::atomic_wait_value_for( &value, 42, 1min );
+	th.join( );
+	daw_ensure( result == daw::wait_status::found );
+	daw_ensure( value == 42 );
+}
+
+DAW_ATTRIB_NOINLINE void test_atomic_wait_value_already_set( ) {
+	auto value = std::atomic<int>{ 42 };
+	daw::atomic_wait_value( &value, 42 );
+	daw_ensure( value == 42 );
+}
+
+DAW_ATTRIB_NOINLINE void test_atomic_wait_value( ) {
+	auto value = std::atomic<int>{ 4 };
+	auto const fn = [&] {
+		std::this_thread::sleep_for( 50ms );
+		--value;
+		std::atomic_notify_one( &value );
+	};
+	auto ths = std::array<std::thread, 4>{ std::thread( fn ), std::thread( fn ),
+	                                       std::thread( fn ), std::thread( fn ) };
+	daw::atomic_wait_value( &value, 0 );
+	for( auto &th : ths ) {
+		th.join( );
+	}
+	daw_ensure( value == 0 );
+}
+
+DAW_ATTRIB_NOINLINE void test_atomic_wait_if_until_timeout( ) {
+	auto value = std::atomic<int>{ };
+	static constexpr auto pred = []( auto const &v ) {
+		return v == 42;
+	};
+	auto result = daw::atomic_wait_if_until(
+	  &value, pred, std::chrono::system_clock::now( ) + 30ms );
+	daw_ensure( result == daw::wait_status::timeout );
+	daw_ensure( value == 0 );
+}
+
+DAW_ATTRIB_NOINLINE void test_atomic_wait_if_until_no_timeout( ) {
+	auto value = std::atomic<int>{ };
+	auto th = std::thread( [&value] {
+		std::this_thread::sleep_for( 500ms );
+		value = 42;
+		std::atomic_notify_one( &value );
+	} );
+	static constexpr auto pred = []( auto const &v ) {
+		return v == 42;
+	};
+	auto const result = daw::atomic_wait_if_until(
+	  &value, pred, std::chrono::system_clock::now( ) + 1min );
+	th.join( );
+	daw_ensure( result == daw::wait_status::found );
+	daw_ensure( value == 42 );
+}
+
+DAW_ATTRIB_NOINLINE void test_atomic_wait_if_for_timeout( ) {
+	auto value = std::atomic<int>{ };
+	static constexpr auto pred = []( auto const &v ) {
+		return v == 42;
+	};
+	auto result = daw::atomic_wait_if_for( &value, pred, 30ms );
+	daw_ensure( result == daw::wait_status::timeout );
+	daw_ensure( value == 0 );
+}
+
+DAW_ATTRIB_NOINLINE void test_atomic_wait_if_for_no_timeout( ) {
+	auto value = std::atomic<int>{ };
+	auto th = std::thread( [&value] {
+		std::this_thread::sleep_for( 500ms );
+		value = 42;
+		std::atomic_notify_one( &value );
+	} );
+	static constexpr auto pred = []( auto const &v ) {
+		return v == 42;
+	};
+	auto const result = daw::atomic_wait_if_for( &value, pred, 1min );
+	th.join( );
+	daw_ensure( result == daw::wait_status::found );
+	daw_ensure( value == 42 );
+}
+
+DAW_ATTRIB_NOINLINE void test_atomic_wait_if( ) {
+	auto value = std::atomic<int>{ 4 };
+	auto const fn = [&] {
+		std::this_thread::sleep_for( 50ms );
+		--value;
+		std::atomic_notify_one( &value );
+	};
+	auto ths = std::array<std::thread, 4>{ std::thread( fn ), std::thread( fn ),
+	                                       std::thread( fn ), std::thread( fn ) };
+	static constexpr auto pred = []( auto const &v ) {
+		return v == 0;
+	};
+	daw::atomic_wait_if( &value, pred );
+	for( auto &th : ths ) {
+		th.join( );
+	}
+	daw_ensure( value == 0 );
+}
+
+DAW_ATTRIB_NOINLINE void test_atomic_wait_until_timeout( ) {
+	auto value = std::atomic<int>{ };
+	auto result = daw::atomic_wait_until(
+	  &value, 0, std::chrono::system_clock::now( ) + 30ms );
+	daw_ensure( result == daw::wait_status::timeout );
+	daw_ensure( value == 0 );
+}
+
+DAW_ATTRIB_NOINLINE void test_atomic_wait_until( ) {
+	auto value = std::atomic<int>{ };
+	auto th = std::thread( [&] {
+		std::this_thread::sleep_for( 100ms );
+		++value;
+		std::atomic_notify_one( &value );
+	} );
+	auto result = daw::atomic_wait_until(
+	  &value, 0, std::chrono::system_clock::now( ) + 1min );
+	th.join( );
+	daw_ensure( result == daw::wait_status::found );
+	daw_ensure( value == 1 );
+}
+
+DAW_ATTRIB_NOINLINE void test_atomic_wait_for_timeout( ) {
+	auto value = std::atomic<int>{ };
+	auto result = daw::atomic_wait_for( &value, 0, 30ms );
+	daw_ensure( result == daw::wait_status::timeout );
+	daw_ensure( value == 0 );
+}
+
+DAW_ATTRIB_NOINLINE void test_atomic_wait_for( ) {
+	auto value = std::atomic<int>{ };
+	auto th = std::thread( [&] {
+		std::this_thread::sleep_for( 100ms );
+		++value;
+		std::atomic_notify_one( &value );
+	} );
+	auto result = daw::atomic_wait_for( &value, 0, 1min );
+	th.join( );
+	daw_ensure( result == daw::wait_status::found );
+	daw_ensure( value == 1 );
+}
+
+int main( ) {
+	test_atomic_wait_value_until_timeout( );
+	test_atomic_wait_value_until_no_timeout( );
+	test_atomic_wait_value_for_timeout( );
+	test_atomic_wait_value_for_no_timeout( );
+	test_atomic_wait_value_already_set( );
+	test_atomic_wait_value( );
+	test_atomic_wait_if_until_timeout( );
+	test_atomic_wait_if_until_no_timeout( );
+	test_atomic_wait_if_for_timeout( );
+	test_atomic_wait_if_for_no_timeout( );
+	test_atomic_wait_if( );
+	test_atomic_wait_until_timeout( );
+	test_atomic_wait_until( );
+	test_atomic_wait_for_timeout( );
+	test_atomic_wait_for( );
+}

--- a/tests/daw_atomic_wait_test.cpp
+++ b/tests/daw_atomic_wait_test.cpp
@@ -18,7 +18,7 @@ using namespace std::chrono_literals;
 
 DAW_ATTRIB_NOINLINE void test_atomic_wait_value_until_timeout( ) {
 	auto value = std::atomic<int>{ };
-	auto result = daw::atomic_wait_value_until(
+	auto result = daw::atomic_wait_value_equal_until(
 	  &value, 42, std::chrono::system_clock::now( ) + 30ms );
 	daw_ensure( result == daw::wait_status::timeout );
 	daw_ensure( value == 0 );
@@ -32,7 +32,7 @@ DAW_ATTRIB_NOINLINE void test_atomic_wait_value_until_no_timeout( ) {
 		value = 42;
 		std::atomic_notify_one( &value );
 	} );
-	auto const result = daw::atomic_wait_value_until(
+	auto const result = daw::atomic_wait_value_equal_until(
 	  &value, 42, std::chrono::system_clock::now( ) + 1min );
 	th.join( );
 	daw_ensure( result == daw::wait_status::found );
@@ -41,7 +41,7 @@ DAW_ATTRIB_NOINLINE void test_atomic_wait_value_until_no_timeout( ) {
 
 DAW_ATTRIB_NOINLINE void test_atomic_wait_value_for_timeout( ) {
 	auto value = std::atomic<int>{ };
-	auto result = daw::atomic_wait_value_for( &value, 42, 30ms );
+	auto result = daw::atomic_wait_value_equal_for( &value, 42, 30ms );
 	daw_ensure( result == daw::wait_status::timeout );
 	daw_ensure( value == 0 );
 }
@@ -54,7 +54,7 @@ DAW_ATTRIB_NOINLINE void test_atomic_wait_value_for_no_timeout( ) {
 		value = 42;
 		std::atomic_notify_one( &value );
 	} );
-	auto const result = daw::atomic_wait_value_for( &value, 42, 1min );
+	auto const result = daw::atomic_wait_value_equal_for( &value, 42, 1min );
 	th.join( );
 	daw_ensure( result == daw::wait_status::found );
 	daw_ensure( value == 42 );
@@ -62,7 +62,7 @@ DAW_ATTRIB_NOINLINE void test_atomic_wait_value_for_no_timeout( ) {
 
 DAW_ATTRIB_NOINLINE void test_atomic_wait_value_already_set( ) {
 	auto value = std::atomic<int>{ 42 };
-	daw::atomic_wait_value( &value, 42 );
+	daw::atomic_wait_value_equal( &value, 42 );
 	daw_ensure( value == 42 );
 }
 
@@ -75,7 +75,7 @@ DAW_ATTRIB_NOINLINE void test_atomic_wait_value( ) {
 	};
 	auto ths = std::array<std::thread, 4>{ std::thread( fn ), std::thread( fn ),
 	                                       std::thread( fn ), std::thread( fn ) };
-	daw::atomic_wait_value( &value, 0 );
+	daw::atomic_wait_value_equal( &value, 0 );
 	for( auto &th : ths ) {
 		th.join( );
 	}

--- a/tests/daw_attributes_test.cpp
+++ b/tests/daw_attributes_test.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) Darrell Wright
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/beached/header_libraries
+//
+
+#include <daw/daw_attributes.h>
+#include <daw/daw_ensure.h>
+
+#include <cstddef>
+
+DAW_ATTRIB_RET_NONNULL
+DAW_ATTRIB_NONNULL( )
+char const *test_attrib_nonnull( char const *ptr, std::ptrdiff_t offset ) {
+	return ptr + offset;
+}
+
+DAW_ATTRIB_RET_NONNULL
+DAW_ATTRIB_NONNULL( ( 1 ) )
+char const *test_attrib_nonnull2( char const *ptr, std::ptrdiff_t offset ) {
+	return ptr + offset;
+}
+
+int main( int, char **argv ) {
+	auto a = test_attrib_nonnull( argv[0], 0 );
+	daw_ensure( a == argv[0] );
+	a = test_attrib_nonnull2( argv[0], 0 );
+	daw_ensure( a == argv[0] );
+}

--- a/tests/daw_concepts_test.cpp
+++ b/tests/daw_concepts_test.cpp
@@ -8,6 +8,18 @@
 
 #include <daw/daw_concepts.h>
 
+#include <type_traits>
+
 static_assert( daw::same_as<int, int> );
+
+inline constexpr auto foo = []( daw::Fn<void()> auto && ) {};
+inline constexpr auto foo_t0 = []( ) {};
+inline constexpr auto foo_t1 = []( ) { return 42; };
+inline constexpr auto foo_t2 = []( int ) { return 42; };
+
+static_assert( std::is_invocable_v<decltype(foo), decltype(foo_t0)> );
+static_assert( std::is_invocable_v<decltype(foo), decltype(foo_t1)> );
+static_assert( not std::is_invocable_v<decltype(foo), decltype(foo_t2)> );
+
 
 int main( ) {}

--- a/tests/daw_pipelines_test.cpp
+++ b/tests/daw_pipelines_test.cpp
@@ -83,7 +83,8 @@ namespace tests {
 		  ")\n{}",
 		  daw::fmt_range( m3 ) );
 
-		for( auto vec = std::vector{1,2,3}; auto [index, value] : EnumerateWith<int>( vec ) ) {
+		for( auto vec = std::vector{ 1, 2, 3 };
+		     auto [index, value] : EnumerateWith<int>( vec ) ) {
 			daw::dump( index * value );
 		}
 	}
@@ -486,6 +487,22 @@ namespace tests {
 		daw::dump( 1, 2, 3, 4 );
 	}
 
+	DAW_ATTRIB_NOINLINE void test029( ) {
+		constexpr auto pm3 =
+		  pipeline( Map( to_letter ), EnumerateFrom( 2 ), To<std::map> );
+		auto const m3 = pm3( iota_view( 0, 26 ) );
+		daw::println(
+		  "\ntest029: pipeline( Map( to_letter ), EnumerateFrom( 2 ), "
+		  "To<std::map> "
+		  ")\n{}",
+		  daw::fmt_range( m3 ) );
+
+		for( auto vec = std::vector{ 1, 2, 3 };
+		     auto [index, value] : EnumerateFrom( 2 )( vec ) ) {
+			daw::dump( index * value );
+		}
+	}
+
 } // namespace tests
 
 int main( ) {
@@ -517,6 +534,7 @@ int main( ) {
 	tests::test026( );
 	tests::test027( );
 	tests::test028( );
+	tests::test029( );
 
 	daw::println( "Done" );
 }


### PR DESCRIPTION
Introduce various atomic wait functions in `daw_atomic_wait.h` to handle waiting on atomic values with or without predicates and timeouts.